### PR TITLE
Allow TTL to be set per-service

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,7 @@ When providing information you will need to fill out the following values.
 * Host - The name of your service, e.g., `service5.mydomain.com`,  and IP address (either v4 or v6)
 * Port - the port where the service can be reached.
 * Priority - the priority of the service.
+* TTL - the time-to-live of the service, overriding the default TTL. If the etcd key also has a TTL, the minimum of this value and the etcd TTL is used.
 
 Adding the service can thus be done with:
 

--- a/server_test.go
+++ b/server_test.go
@@ -184,7 +184,7 @@ func TestDNS(t *testing.T) {
 	defer s.Stop()
 
 	for _, serv := range services {
-		m := &Service{Host: serv.Host, Port: serv.Port}
+		m := &Service{Host: serv.Host, Port: serv.Port, Ttl: serv.Ttl}
 		addService(t, s, serv.key, 0, m)
 		defer delService(t, s, serv.key)
 	}
@@ -325,6 +325,7 @@ var services = []*Service{
 	{Host: "100.server1.development.region1.skydns.test", key: "2.cname.skydns.test."},
 	{Host: "4.cname.skydns.test", key: "3.cname.skydns.test."},
 	{Host: "3.cname.skydns.test", key: "4.cname.skydns.test."},
+	{Host: "10.0.0.2", key: "ttl.skydns.test.", Ttl: 360},
 }
 
 var dnsTestCases = []dnsTestCase{
@@ -363,6 +364,11 @@ var dnsTestCases = []dnsTestCase{
 	{
 		Qname: "105.server3.production.region2.skydns.test.", Qtype: dns.TypeAAAA,
 		Answer: []dns.RR{newAAAA("105.server3.production.region2.skydns.test. 3600 AAAA 2001::8:8:8:8")},
+	},
+	// TTL Test
+	{
+		Qname: "ttl.skydns.test.", Qtype: dns.TypeA,
+		Answer: []dns.RR{newA("ttl.skydns.test. 360 A 10.0.0.2")},
 	},
 	// CNAME Test
 	{

--- a/service.go
+++ b/service.go
@@ -19,8 +19,8 @@ type Service struct {
 	Host     string `json:"host,omitempty"`
 	Port     int    `json:"port,omitempty"`
 	Priority int    `json:"priority,omitempty"`
+	Ttl      uint32 `json:"ttl,omitempty"`
 
-	ttl uint32
 	key string
 }
 


### PR DESCRIPTION
This is in addition to the etcd-provided TTL. If both the etcd TTL and a record TTL are set, we use the smaller of the two. If neither are set, we fall back to the server's default.
