### PR TITLE
Improved handling of environment variables and parameters

### DIFF
--- a/main.go
+++ b/main.go
@@ -16,15 +16,13 @@ import (
 )
 
 var (
-	machines    = strings.Split(os.Getenv("ETCD_MACHINES"), ",")      // list of URLs to etcd
-	nameservers = strings.Split(os.Getenv("SKYDNS_NAMESERVERS"), ",") // list of nameservers
-	tlskey      = os.Getenv("ETCD_TLSKEY")                            // TLS private key path
-	tlspem      = os.Getenv("ETCD_TLSPEM")                            // X509 certificate
-	config      = &Config{ReadTimeout: 0, Domain: "", DnsAddr: "", DNSSEC: ""}
-	nameserver  = ""
-	machine     = ""
-	discover    = false
-	verbose     = false
+	tlskey     = ""
+	tlspem     = ""
+	config     = &Config{ReadTimeout: 0, Domain: "", DnsAddr: "", DNSSEC: ""}
+	nameserver = ""
+	machine    = ""
+	discover   = false
+	verbose    = false
 )
 
 const (
@@ -33,28 +31,22 @@ const (
 	RCacheTtl      = 60
 )
 
-func init() {
-	flag.StringVar(&config.Domain, "domain",
-		func() string {
-			if x := os.Getenv("SKYDNS_DOMAIN"); x != "" {
-				return x
-			}
-			return "skydns.local."
-		}(), "domain to anchor requests to (SKYDNS_DOMAIN)")
-	flag.StringVar(&config.DnsAddr, "addr",
-		func() string {
-			if x := os.Getenv("SKYDNS_ADDR"); x != "" {
-				return x
-			}
-			return "127.0.0.1:53"
-		}(), "ip:port to bind to (SKYDNS_ADDR)")
+func getEnv(key, def string) string {
+	if x := os.Getenv(key); x != "" {
+		return x
+	}
+	return def
+}
 
-	flag.StringVar(&nameserver, "nameservers", "", "nameserver address(es) to forward (non-local) queries to e.g. 8.8.8.8:53,8.8.4.4:53")
-	flag.StringVar(&machine, "machines", "", "machine address(es) running etcd")
+func init() {
+	flag.StringVar(&config.Domain, "domain", getEnv("SKYDNS_DOMAIN", "skydns.local."), "domain to anchor requests to (SKYDNS_DOMAIN)")
+	flag.StringVar(&config.DnsAddr, "addr", getEnv("SKYDNS_ADDR", "127.0.0.1:53"), "ip:port to bind to (SKYDNS_ADDR)")
+	flag.StringVar(&nameserver, "nameservers", getEnv("SKYDNS_NAMESERVERS", ""), "nameserver address(es) to forward (non-local) queries to e.g. 8.8.8.8:53,8.8.4.4:53")
+	flag.StringVar(&machine, "machines", getEnv("ETCD_MACHINES", ""), "machine address(es) running etcd")
 	flag.StringVar(&config.DNSSEC, "dnssec", "", "basename of DNSSEC key file e.q. Kskydns.local.+005+38250")
 	flag.StringVar(&config.Local, "local", "", "optional unique value for this skydns instance")
-	flag.StringVar(&tlskey, "tls-key", "", "TLS Private Key path")
-	flag.StringVar(&tlspem, "tls-pem", "", "X509 Certificate")
+	flag.StringVar(&tlskey, "tls-key", getEnv("ETCD_TLSKEY", ""), "TLS Private Key path")
+	flag.StringVar(&tlspem, "tls-pem", getEnv("ETCD_TLSPEM", ""), "X509 Certificate")
 	flag.DurationVar(&config.ReadTimeout, "rtimeout", 2*time.Second, "read timeout")
 	flag.BoolVar(&config.RoundRobin, "round-robin", true, "round robin A/AAAA replies")
 	flag.BoolVar(&discover, "discover", false, "discover new machines by watching /v2/_etcd/machines")
@@ -70,6 +62,7 @@ func init() {
 
 func main() {
 	flag.Parse()
+	machines := strings.Split(machine, ",")
 	client := NewClient(machines)
 	if nameserver != "" {
 		config.Nameservers = strings.Split(nameserver, ",")


### PR DESCRIPTION
As discussed in #55, the handling of environment variables is somewhat broken. So i've simplified the whole thing and through that also fixed the previously broken handling of the `SKYDNS_NAMESERVERS` environment variable as well as the broken `-machines` parameter.

@miekg ... don't forget to merge #55 as well ... and yes .. i am up to it :)
