### PR TITLE
Fixed typo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ may be set:
 * `min_ttl`: minimum TTL in seconds to use on NXDOMAIN, defaults to 30.
 * `scache`: the capacity of the DNSSEC signature cache, defaults to 10000 records if not set.
 * `rcache`: the capacity of the response cache, defaults to 0 records if not set.
-* `rcache-ttl`: the TTL of the response cache, defaults to 60 if not set.
+* `rcache_ttl`: the TTL of the response cache, defaults to 60 if not set.
 * `systemd`: bind to socket(s) activated by systemd (ignore -addr).
 
 To set the configuration, use something like:


### PR DESCRIPTION
JSON config param `rcache-ttl` to `rcache_ttl`
