### PR TITLE
Use cert and key in correct order for TLS conn. to Etcd.

### DIFF
--- a/main.go
+++ b/main.go
@@ -67,7 +67,7 @@ func init() {
 func main() {
 	flag.Parse()
 	machines := strings.Split(machine, ",")
-	client := newClient(machines, tlskey, tlspem, cacert)
+	client := newClient(machines, tlspem, tlskey, cacert)
 	if nameserver != "" {
 		for _, hostPort := range strings.Split(nameserver, ",") {
 			if err := validateHostPort(hostPort); err != nil {


### PR DESCRIPTION
In newClient the 'tlspem' and 'tlskey' parameters were reversed.
Todo: tests ssl conn. to Etcd.

Closes issue #130