### PR TITLE
Support for RFC2782 SRV lookups with _ldap._tcp.example.com

### DIFF
--- a/msg/service.go
+++ b/msg/service.go
@@ -76,6 +76,10 @@ func PathWithWildcard(s string) (string, bool) {
 		if k == "*" {
 			return path.Join(append([]string{"/skydns/"}, l[:i]...)...), true
 		}
+		if strings.HasPrefix(k, "_") {
+			// escape leading _ to avoid etcd treating the key as hidden
+			l[i] = strings.Replace(k, "_", "%5F", 1)
+		}
 	}
 	return path.Join(append([]string{"/skydns/"}, l...)...), false
 }
@@ -87,6 +91,12 @@ func Path(s string) string {
 	for i, j := 0, len(l)-1; i < j; i, j = i+1, j-1 {
 		l[i], l[j] = l[j], l[i]
 	}
+	for i, k := range l {
+		if strings.HasPrefix(k, "_") {
+			// escape leading _ to avoid etcd treating the key as hidden
+			l[i] = strings.Replace(k, "_", "%5F", 1)
+		}
+	}
 	return path.Join(append([]string{"/skydns/"}, l...)...)
 }
 
@@ -96,6 +106,12 @@ func Domain(s string) string {
 	// start with 1, to strip /skydns
 	for i, j := 1, len(l)-1; i < j; i, j = i+1, j-1 {
 		l[i], l[j] = l[j], l[i]
+	}
+	for i, k := range l {
+		if strings.HasPrefix(k, "%5F") {
+			// un-escape etcd hidden key prefix
+			l[i] = strings.Replace(k, "%5F", "_", 1)
+		}
 	}
 	return dns.Fqdn(strings.Join(l[1:len(l)-1], "."))
 }

--- a/msg/service_test.go
+++ b/msg/service_test.go
@@ -39,3 +39,25 @@ func TestSplit255(t *testing.T) {
 		t.Fail()
 	}
 }
+
+func testDomainPath(t *testing.T, domain string, expected string) {
+	path := Path(domain)
+	if path != expected {
+		t.Logf("Path %s\n", domain)
+		t.Logf("%s %v\n", path, expected)
+		t.Fail()
+	}
+
+	roundtrip := Domain(path)
+	if roundtrip != domain + "." {
+		t.Logf("Domain %s\n", path)
+		t.Logf("%s %v\n", roundtrip, domain)
+		t.Fail()
+	}
+}
+
+
+func TestPath(t *testing.T) {
+	testDomainPath(t, "test.skydns.local", "/skydns/local/skydns/test")
+	testDomainPath(t, "_ldap._tcp.skydns.local", "/skydns/local/skydns/%5Ftcp/%5Fldap")
+}


### PR DESCRIPTION
[RFC2782](https://tools.ietf.org/html/rfc2782) describes a schema for registering multiple services under a given domain name, using SRV queries of the form `_ldap._tcp.example.com`. Unfortunately it doesn't seem like skydns using etcd as a backend supports lookups of this form, since `_`-prefixed names are interepreted by etcd as hidden keys, and skydns is thus not able to look them up recursively. This makes it difficult to use existing SRV query libraries such as Python [srvlookup](https://pypi.python.org/pypi/srvlookup) to query SRV records from skydns.

Here's a proposal to rewrite the SRV lookup `_`-prefixes into `.`-suffixes:

	_ldap._tcp.test.skydns.local -> /skydns/local/skydns/test.tcp.ldap/

Using `.` as a suffix seemed to make the most sense to me, since such keys are unlikely to be used in current skydns schemes. However, this also means that it's probably a bad to place IP addresses directly in the service records, since the generated A records will have labels with escaped label separators - the service records should instead point to a separate host record in skydns instead.

Consider this pull request more of an inital proof-of-concept; if the feature and the etcd key schema makes sense, then I'll be happy to polish the code up further.

Example:

	$ etcdctl ls --recursive -p /skydns/local/skydns/docker-registry
	/skydns/local/skydns/docker-registry/test4/
	/skydns/local/skydns/docker-registry/test4/docker-registry
	/skydns/local/skydns/docker-registry/test3/
	/skydns/local/skydns/docker-registry/test3/docker-registry
	$ etcdctl ls --recursive -p /skydns/local/skydns/docker-registry.tcp.http
	/skydns/local/skydns/docker-registry.tcp.http/test3/
	/skydns/local/skydns/docker-registry.tcp.http/test3/docker-registry
	/skydns/local/skydns/docker-registry.tcp.http/test4/
	/skydns/local/skydns/docker-registry.tcp.http/test4/docker-registry
	$ etcdctl get /skydns/local/skydns/docker-registry/test3/docker-registry
	{"host":"10.3.107.14"}
	$ etcdctl get /skydns/local/skydns/docker-registry.tcp.http/test3/docker-registry
	{"host":"docker-registry.test3.docker-registry.skydns.local","port":5000}

	$ dig +short @localhost _http._tcp.docker-registry.skydns.local SRV
	10 50 5000 docker-registry.test3.docker-registry.skydns.local.
	10 50 5000 docker-registry.test4.docker-registry.skydns.local.
	$ dig +short @localhost docker-registry.test3.docker-registry.skydns.local. docker-registry.test4.docker-registry.skydns.local.
	10.3.107.14
	10.4.107.11

	$ python
	>>> import srvlookup
	>>> for srv in srvlookup.lookup('http', domain='docker-registry.skydns.local'): print(srv)
	SRV(host='docker-registry.test4.docker-registry.skydns.local', port=5000, priority=10, weight=50)
	SRV(host='docker-registry.test3.docker-registry.skydns.local', port=5000, priority=10, weight=50)
