### PR TITLE
Add TargetStrip to msg.Service

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,6 @@ language: go
 
 go:
   - 1.4
-  - 1.3
 
 install:
   - go get github.com/coreos/etcd

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ Then get and compile SkyDNS:
     go build -v
 
 SkyDNS' configuration is stored *in* etcd: but there are also flags and
-environment variabes you can set. To start SkyDNS, set the etcd machines with
+environment variables you can set. To start SkyDNS, set the etcd machines with
 the environment variable ETCD_MACHINES:
 
     export ETCD_MACHINES='http://192.168.0.1:4001,http://192.168.0.2:4001'
@@ -67,7 +67,7 @@ SkyDNS' configuration is stored in etcd as a JSON object under the key
 * `local`: optional unique value for this skydns instance, default is none. This is returned
     when queried for `local.dns.skydns.local`.
 * `round_robin`: enable round-robin sorting for A and AAAA responses, defaults to true.
-    Note that packets containing more than one CNAME are excempt from this (see issue #128 on Github).
+    Note that packets containing more than one CNAME are exempt from this (see issue #128 on Github).
 * `nameservers`: forward DNS requests to these nameservers (array of IP:port combination), when not
     authoritative for a domain.
 * `read_timeout`: network read timeout, for DNS and talking with etcd.
@@ -258,8 +258,9 @@ Here all three entries of the `east` are returned.
 
 There is one other feature at play here. The second and third names,
 `{4,6}.rails.staging.east.skydns.local`, only had an IP record configured. Here
-SkyDNS used the ectd path to construct a target name and then puts the actual IP
-address in the additional section. Directly querying for the A records of
+SkyDNS used the ectd path (also see `TargetStrip`) to
+construct a target name and then puts the actual IP address in the additional
+section. Directly querying for the A records of
 `4.rails.staging.east.skydns.local.` of course also works:
 
     % dig @localhost -p 5354 +noall +answer A 4.rails.staging.east.skydns.local.
@@ -297,10 +298,10 @@ back a SRV record such as:
     % dig @localhost 4.rails.staging.east.skydns.local SRV
 
     ;; ANSWER SECTION:
-    4.rails.staging.east.skydns.local 3600 IN SRV 10 100 8080 10.0.1.125.
+    4.rails.staging.east.skydns.local 3600 IN SRV 10 100 8080 10.0.1.125
 
 Where the target of the SRV is an IP address. This is not how SRV records work.
-SkyDNS will in this case synthesize an domain name and adds the actual IP
+SkyDNS will in this case synthesize a domain name and add the actual IP
 address to the additional section of the response:
 
     % dig @localhost 4.rails.staging.east.skydns.local SRV
@@ -413,8 +414,8 @@ Registers `ns.dns.skydns.local` as a nameserver with IP address 172.16.0.1:
     ns.dns.skydns.local.    3600    IN  A   172.16.0.1
 
 The first nameserver should have the hostname `ns`  (as this is used in the SOA
-record). Having the nameserver(s) in etcd make sense because usualy it is hard
-for SkyDNS to figure this out by itself, espcially when running behind NAT or
+record). Having the nameserver(s) in etcd make sense because usually it is hard
+for SkyDNS to figure this out by itself, especially when running behind NAT or
 running on 127.0.0.1:53 and being forwarded packets IPv6 packets, etc. etc.
 
 

--- a/README.md
+++ b/README.md
@@ -1,13 +1,14 @@
 # SkyDNS [![Build Status](https://travis-ci.org/skynetservices/skydns.png?branch=master)](https://travis-ci.org/skynetservices/skydns)
 *Version 2.1.0a*
 
-SkyDNS is a distributed service for announcement and discovery of services built on
-top of [etcd](https://github.com/coreos/etcd). It utilizes DNS queries
-to discover available services. This is done by leveraging SRV records in DNS,
-with special meaning given to subdomains, priorities and weights.
+SkyDNS is a distributed service for announcement and discovery of services built
+on top of [etcd](https://github.com/coreos/etcd). It utilizes DNS queries to
+discover available services. This is done by leveraging SRV records in DNS, with
+special meaning given to subdomains, priorities and weights.
 
-This is the original [announcement blog post](http://blog.gopheracademy.com/skydns) for version 1.
-Since then, SkyDNS has seen some changes, most notably the ability to use etcd as a backend.
+This is the original [announcement blog
+post](http://blog.gopheracademy.com/skydns) for version 1. Since then, SkyDNS
+has seen some changes, most notably the ability to use etcd as a backend.
 [Here you can find the SkyDNS2 announcement](http://miek.nl/posts/2014/Jun/08/announcing%20SkyDNS%20version%202/).
 
 # Changes since version 1
@@ -19,8 +20,9 @@ SkyDNS2:
 * Is a thin layer above etcd, that translates etcd keys and values to the DNS.
 * Does DNSSEC with NSEC3 instead of NSEC.
 
-Note that bugs in SkyDNS1 will still be fixed, but the main development effort will be focussed on version 2.
-[Version 1 of SkyDNS can be found here](https://github.com/skynetservices/skydns1).
+Note that bugs in SkyDNS1 will still be fixed, but the main development effort
+will be focussed on version 2. [Version 1 of SkyDNS can be found
+here](https://github.com/skynetservices/skydns1).
 
 # Future ideas
 
@@ -35,15 +37,17 @@ Then get and compile SkyDNS:
     cd $GOPATH/src/github.com/skynetservices/skydns
     go build -v
 
-SkyDNS' configuration is stored *in* etcd: but there are also flags and environment variabes
-you can set. To start SkyDNS, set the etcd machines with the environment variable ETCD_MACHINES:
+SkyDNS' configuration is stored *in* etcd: but there are also flags and
+environment variabes you can set. To start SkyDNS, set the etcd machines with
+the environment variable ETCD_MACHINES:
 
     export ETCD_MACHINES='http://192.168.0.1:4001,http://192.168.0.2:4001'
     ./skydns
 
-If `ETCD_MACHINES` is not set, SkyDNS will default to using `http://127.0.0.1:4001` to connect to etcd.
-Or you can use the flag `-machines`. Auto-discovering new machines added to the network can
-be enabled by enabling the flag `-discover`.
+If `ETCD_MACHINES` is not set, SkyDNS will default to using
+`http://127.0.0.1:4001` to connect to etcd. Or you can use the flag `-machines`.
+Auto-discovering new machines added to the network can be enabled by enabling
+the flag `-discover`.
 
 Optionally (but recommended) give it a nameserver:
 
@@ -53,8 +57,8 @@ Optionally (but recommended) give it a nameserver:
 Also see the section "NS Records".
 
 ## Configuration
-SkyDNS' configuration is stored in etcd as a JSON object under the key `/skydns/config`. The following parameters
-may be set:
+SkyDNS' configuration is stored in etcd as a JSON object under the key
+`/skydns/config`. The following parameters may be set:
 
 * `dns_addr`: IP:port on which SkyDNS should listen, defaults to `127.0.0.1:53`.
 * `domain`: domain for which SkyDNS is authoritative, defaults to `skydns.local.`.
@@ -79,10 +83,12 @@ To set the configuration, use something like:
     curl -XPUT http://127.0.0.1:4001/v2/keys/skydns/config \
         -d value='{"dns_addr":"127.0.0.1:5354","ttl":3600, "nameservers": ["8.8.8.8:53","8.8.4.4:53"]}'
 
-SkyDNS needs to be restarted for configuration changes to take effect. This might change, so that SkyDNS
-can re-read the config from etcd after a HUP signal.
+SkyDNS needs to be restarted for configuration changes to take effect. This
+might change, so that SkyDNS can re-read the config from etcd after a HUP
+signal.
 
-You can also use the command line options, however the settings in etcd take precedence.
+You can also use the command line options, however the settings in etcd take
+precedence.
 
 ### Commandline flags
 
@@ -111,7 +117,8 @@ SkyDNS uses these environment variables:
 * `ETCD_CACERT` - path of TLS certificate authority public key
 * `SKYDNS_ADDR` - specify address to bind to
 * `SKYDNS_DOMAIN` - set a default domain if not specified by etcd config
-* `SKYDNS_NAMESERVERS` - set a list of nameservers to forward DNS requests to when not authoritative for a domain, "8.8.8.8:53,8.8.4.4:53".
+* `SKYDNS_NAMESERVERS` - set a list of nameservers to forward DNS requests to
+  when not authoritative for a domain, "8.8.8.8:53,8.8.4.4:53".
 
 And these are used for statistics:
 
@@ -121,20 +128,25 @@ And these are used for statistics:
 
 ### SSL Usage and Authentication with Client Certificates
 
-In order to connect to an SSL-secured etcd, you will at least need to set ETCD_CACERT to be the public key
-of the Certificate Authority which signed the server certificate.
+In order to connect to an SSL-secured etcd, you will at least need to set
+ETCD_CACERT to be the public key of the Certificate Authority which signed the
+server certificate.
 
-If the SSL-secured etcd expects client certificates to authorize connections, you also need to set ETCD_TLSKEY
-to the *private* key of the client, and ETCD_TLSPEM to the *public* key of the client.
+If the SSL-secured etcd expects client certificates to authorize connections,
+you also need to set ETCD_TLSKEY to the *private* key of the client, and
+ETCD_TLSPEM to the *public* key of the client.
 
 ## Service Announcements
-Announce your service by submitting JSON over HTTP to etcd with information about your service.
-This information will then be available for queries via DNS.
+Announce your service by submitting JSON over HTTP to etcd with information
+about your service. This information will then be available for queries via DNS.
 We use the directory `/skydns` to anchor all names.
 
-When providing information you will need to fill out (some of) the following values.
+When providing information you will need to fill out (some of) the following
+values.
 
-* Path - The path of the key in etcd, e.g. if the domain you want to register is "rails.production.east.skydns.local", you need to reverse it and replace the dots with slashes. So the name here becomes:
+* Path - The path of the key in etcd, e.g. if the domain you want to
+  register is "rails.production.east.skydns.local", you need to reverse it
+  and replace the dots with slashes. So the name here becomes:
     `local/skydns/east/production/rails`.
   Then prefix the `/skydns/` string too, so the final path becomes
     `/v2/keys/skydns/local/skydns/east/production/rails`
@@ -143,7 +155,8 @@ When providing information you will need to fill out (some of) the following val
 * Priority - the priority of the service, the lower the value, the more preferred;
 * Weight - a weight factor that will be used for services with the same Priority;
 * Text - text you want to add (this returned when doing a TXT query);
-* TTL - the time-to-live of the service, overriding the default TTL. If the etcd key also has a TTL, the minimum of this value and the etcd TTL is used.
+* TTL - the time-to-live of the service, overriding the default TTL. If the etcd
+  key also has a TTL, the minimum of this value and the etcd TTL is used.
 
 Path is the only mandatory field.
 
@@ -157,8 +170,9 @@ Or with [`etcdctl`](https://github.com/coreos/etcdctl):
     etcdctl set /skydns/local/skydns/east/production/rails \
         '{"host":"service5.example.com","priority":20}'
 
-When doing a SRV query for these keys an SRV record is returned with the priority and a certain weight.
-The weight of a service is calculated as follows. We treat weight as a percentage, so if there are
+When doing a SRV query for these keys an SRV record is returned with the
+priority and a certain weight. The weight of a service is calculated as follows.
+We treat weight as a percentage, so if there are
 3 services, the weight is set to 33 for each:
 
 | Service | Weight  | SRV.Weight |
@@ -167,7 +181,8 @@ The weight of a service is calculated as follows. We treat weight as a percentag
 |    b    |   100   |    33      |
 |    c    |   100   |    33      |
 
-If we add other weights to the equation some services will get a different Weight:
+If we add other weights to the equation some services will get a different
+Weight:
 
 | Service | Weight  | SRV.Weight |
 | --------| ------- | ---------- |
@@ -175,15 +190,19 @@ If we add other weights to the equation some services will get a different Weigh
 |    b    |   100   |    28      |
 |    c    |   130   |    37      |
 
-Note, all calculations are rounded down, so the sum total might be lower than 100.
+Note, all calculations are rounded down, so the sum total might be lower than
+100.
 
-When querying the DNS for services you can use wildcards or query for subdomains. See the section named "Wildcards" below for more information.
+When querying the DNS for services you can use wildcards or query for
+subdomains. See the section named "Wildcards" below for more information.
 
 ## Service Discovery via the DNS
 
-You can find services by querying SkyDNS via any DNS client or utility. It uses a known domain syntax with subdomains to find matching services.
+You can find services by querying SkyDNS via any DNS client or utility. It uses
+a known domain syntax with subdomains to find matching services.
 
-For the purpose of this document, let's suppose we have added the following services to etcd:
+For the purpose of this document, let's suppose we have added the following
+services to etcd:
 
 * 1.rails.production.east.skydns.local, mapping to service1.example.com
 * 2.rails.production.west.skydns.local, mapping to service2.example.com
@@ -213,9 +232,12 @@ Testing one of the names with `dig`:
 
 ### Wildcards
 
-Of course using the full names isn't *that* useful, so SkyDNS lets you query for subdomains, and returns responses based upon the amount of services matched by the subdomain or from the wildcard query.
+Of course using the full names isn't *that* useful, so SkyDNS lets you query for
+subdomains, and returns responses based upon the amount of services matched by
+the subdomain or from the wildcard query.
 
-If we are interested in all the servers in the `east` region, we simply omit the rightmost labels from our query:
+If we are interested in all the servers in the `east` region, we simply omit the
+rightmost labels from our query:
 
     % dig @localhost SRV east.skydns.local
 
@@ -233,15 +255,20 @@ If we are interested in all the servers in the `east` region, we simply omit the
 
 Here all three entries of the `east` are returned.
 
-There is one other feature at play here. The second and third names, `{4,6}.rails.staging.east.skydns.local`, only had an IP record configured. Here SkyDNS used the ectd path to construct a target name and then puts the actual IP address in the additional section. Directly querying for the A records of `4.rails.staging.east.skydns.local.` of course also works:
+There is one other feature at play here. The second and third names,
+`{4,6}.rails.staging.east.skydns.local`, only had an IP record configured. Here
+SkyDNS used the ectd path to construct a target name and then puts the actual IP
+address in the additional section. Directly querying for the A records of
+`4.rails.staging.east.skydns.local.` of course also works:
 
     % dig @localhost -p 5354 +noall +answer A 4.rails.staging.east.skydns.local.
 
     4.rails.staging.east.skydns.local. 3600 IN A    10.0.1.125
 
-Another way to leads to the same result it to query for `*.east.skydns.local`, you even put the wildcard
-(the `*`) in the middle of a name `staging.*.skydns.local` is a valid query, which returns all name
-in staging, regardless of the region. Multiple wildcards per name are also permitted.
+Another way to leads to the same result it to query for `*.east.skydns.local`,
+you even put the wildcard (the `*`) in the middle of a name
+`staging.*.skydns.local` is a valid query, which returns all name in staging,
+regardless of the region. Multiple wildcards per name are also permitted.
 
 ### Examples
 
@@ -265,7 +292,8 @@ Get all Services in staging.east:
     6.rails.staging.east.skydns.local. 3600 IN AAAA 2003::8:1
 
 #### A/AAAA Records
-To return A records, simply run a normal DNS query for a service matching the above patterns.
+To return A records, simply run a normal DNS query for a service matching the
+above patterns.
 
 Now do a normal DNS query:
 
@@ -285,9 +313,10 @@ listed, so this is only useful when you're querying for services running on
 ports known to you in advance.
 
 #### CNAME Records
-If for an A or AAAA query the IP address can not be parsed, SkyDNS will try to see if there is
-a chain of names that will lead to an IP address. The chain can not be longer than 8. So for instance
-if the following services have been registered:
+If for an A or AAAA query the IP address can not be parsed, SkyDNS will try to
+see if there is a chain of names that will lead to an IP address. The chain can
+not be longer than 8. So for instance if the following services have been
+registered:
 
     curl -XPUT http://127.0.0.1:4001/v2/keys/skydns/local/skydns/east/production/rails/1 \
         -d value='{"host":"service1.skydns.local","port":8080}'
@@ -297,17 +326,21 @@ and
     curl -XPUT http://127.0.0.1:4001/v2/keys/skydns/local/skydns/service1 \
         -d value='{"host":"10.0.2.15","port":8080}'
 
-We have created the following CNAME chain: `1.rails.production.east.skydns.local` -> `service1.skydns.local` ->
-`10.0.2.15`. If you then query for an A or AAAA for 1.rails.production.east.skydns.local SkyDNS returns:
+We have created the following CNAME chain:
+`1.rails.production.east.skydns.local` -> `service1.skydns.local` ->
+`10.0.2.15`. If you then query for an A or AAAA for
+1.rails.production.east.skydns.local SkyDNS returns:
 
     1.rails.production.east.skydns.local. 3600  IN  CNAME   service1.skydns.local.
     service1.skydns.local.                 3600  IN  A       10.0.2.15
 
 ##### External Names
 
-If the CNAME chains leads to a name that falls outside of the domain (i.e. does not end with `skydns.local.`),
-a.k.a. an external name, SkyDNS will attempt to resolve that name using the supplied nameservers. If this succeeds
-the reply is concatenated to the current one and send to the client. So if we register this service:
+If the CNAME chains leads to a name that falls outside of the domain (i.e. does
+not end with `skydns.local.`), a.k.a. an external name, SkyDNS will attempt to
+resolve that name using the supplied nameservers. If this succeeds the reply is
+concatenated to the current one and send to the client. So if we register this
+service:
 
     curl -XPUT http://127.0.0.1:4001/v2/keys/skydns/local/skydns/east/production/rails/1 \
         -d value='{"host":"www.miek.nl","port":8080}'
@@ -318,22 +351,25 @@ Doing an A/AAAA query for this will lead to the following response:
     www.miek.nl.            3600    IN      CNAME   a.miek.nl.
     a.miek.nl.              3600    IN      A       176.58.119.54
 
-The first CNAME is generated from within SkyDNS, the other CNANE is returned from the remote name server.
+The first CNAME is generated from within SkyDNS, the other CNANE is returned
+from the remote name server.
 
 #### TXT Records
 
-SkyDNS also allows you to query for TXT records. Just register a json with the 'text' field set.
+SkyDNS also allows you to query for TXT records. Just register a json with the
+'text' field set.
 
 #### NS Records
 
-For DNS to work properly SkyDNS needs to tell peers its nameservers. This information is stored
-inside etcd, in the key `local/skydns/dns/`. There multiple services maybe stored. Note these
-services MUST use IP address, using names will not work. For instance:
+For DNS to work properly SkyDNS needs to tell peers its nameservers. This
+information is stored inside etcd, in the key `local/skydns/dns/`. There
+multiple services maybe stored. Note these services MUST use IP address, using
+names will not work. For instance:
 
     curl -XPUT http://127.0.0.1:4001/v2/keys/skydns/local/skydns/dns/ns \
         -d value='{"host":"172.16.0.1"}'
 
-Registers `ns.dns.skydns.local` as a nameserver with ip address 172.16.0.1:
+Registers `ns.dns.skydns.local` as a nameserver with IP address 172.16.0.1:
 
     % dig @localhost NS skydns.local
 
@@ -346,22 +382,24 @@ Registers `ns.dns.skydns.local` as a nameserver with ip address 172.16.0.1:
     ;; ADDITIONAL SECTION:
     ns.dns.skydns.local.    3600    IN  A   172.16.0.1
 
-The first nameserver should have the hostname `ns`  (as this is used in the SOA record). Having the nameserver(s)
-in etcd make sense because usualy it is hard for SkyDNS to figure this out by itself, espcially when
-running behind NAT or running on 127.0.0.1:53 and being forwarded packets IPv6 packets, etc. etc.
+The first nameserver should have the hostname `ns`  (as this is used in the SOA
+record). Having the nameserver(s) in etcd make sense because usualy it is hard
+for SkyDNS to figure this out by itself, espcially when running behind NAT or
+running on 127.0.0.1:53 and being forwarded packets IPv6 packets, etc. etc.
 
 #### PTR Records: Reverse Addresses
 
-When registering a service with an IP address only, you might also want to register
-the reverse (the hostname the address points to). In the DNS these records are called
-PTR records.
+When registering a service with an IP address only, you might also want to
+register the reverse (the hostname the address points to). In the DNS these
+records are called PTR records.
 
-So looking back at some of the services in the section "Service Discovery via the DNS",
-we register these IP only ones:
+So looking back at some of the services in the section "Service Discovery via
+the DNS", we register these IP only ones:
 
     4.rails.staging.east.skydns.local. 10.0.1.125
 
-To add the reverse of these address you need to add the following names and values:
+To add the reverse of these address you need to add the following names and
+values:
 
     125.1.0.10.in-addr.arpa. service1.example.com.
 
@@ -379,48 +417,53 @@ This also works for IPv6 addresses, except that the reverse path is quite long.
 
 #### DNS Forwarding
 
-By specifying nameservers in SkyDNS's config, for instance `8.8.8.8:53,8.8.4.4:53`,
-you create a DNS forwarding proxy. In this case it round-robins between the two
-nameserver IPs mentioned.
+By specifying nameservers in SkyDNS's config, for instance
+`8.8.8.8:53,8.8.4.4:53`, you create a DNS forwarding proxy. In this case it
+round-robins between the two nameserver IPs mentioned.
 
-Requests for which SkyDNS isn't authoritative will be forwarded and proxied back to
-the client. This means that you can set SkyDNS as the primary DNS server in
-`/etc/resolv.conf` and use it for both service discovery and normal DNS operations.
+Requests for which SkyDNS isn't authoritative will be forwarded and proxied back
+to the client. This means that you can set SkyDNS as the primary DNS server in
+`/etc/resolv.conf` and use it for both service discovery and normal DNS
+operations.
 
 #### DNSSEC
 
-SkyDNS supports signing DNS answers, also known as DNSSEC. To use it, you need to
-create a DNSSEC keypair and use that in SkyDNS. For instance, if the domain for
-SkyDNS is `skydns.local`:
+SkyDNS supports signing DNS answers, also known as DNSSEC. To use it, you need
+to create a DNSSEC keypair and use that in SkyDNS. For instance, if the domain
+for SkyDNS is `skydns.local`:
 
     % dnssec-keygen skydns.local
     Generating key pair............++++++ ...................................++++++
     Kskydns.local.+005+49860
 
-This creates two files with the basename `Kskydns.local.+005.49860`, one with the
-extension `.key` (this holds the public key) and one with the extension `.private` which
-holds the private key. The basename of these files should be given to SkyDNS's DNSSEC configuration
-option like so (together with some other options):
+This creates two files with the basename `Kskydns.local.+005.49860`, one with
+the extension `.key` (this holds the public key) and one with the extension
+`.private` which holds the private key. The basename of these files should be
+given to SkyDNS's DNSSEC configuration option like so (together with some other
+options):
 
     curl -XPUT http://127.0.0.1:4001/v2/keys/skydns/config -d \
         value='{"dns_addr":"127.0.0.1:5354","dnssec":"Kskydns.local.+005+55656"}'
 
-If you then query with `dig +dnssec` you will get signatures, keys and NSEC3 records returned.
-Authenticated denial of existence is implemented using NSEC3 white lies,
-see [RFC7129](http://tools.ietf.org/html/rfc7129), Appendix B.
+If you then query with `dig +dnssec` you will get signatures, keys and NSEC3
+records returned. Authenticated denial of existence is implemented using NSEC3
+white lies, see [RFC7129](http://tools.ietf.org/html/rfc7129), Appendix B.
 
 #### Host Local Values
 
 SkyDNS supports storing values which are specific for that *instance* of SkyDNS.
 
-This can be useful when you have SkyDNS running on multiple hosts, but want to store values that are specific
-for a single host. For example the public IP-address of the host or the IP-address on the tenant network.
+This can be useful when you have SkyDNS running on multiple hosts, but want to
+store values that are specific for a single host. For example the public
+IP-address of the host or the IP-address on the tenant network.
 
-To do that you need to specify a unique value for that host with `-local`. A good unique value for that
-would be an UUID which you can generate with `uuidgen` for instance.
+To do that you need to specify a unique value for that host with `-local`.
+A good unique value for that would be an UUID which you can generate with
+`uuidgen` for instance.
 
-That unique value is used as a path in etcd to store the values separately from the normal values. It is still stored
-in the etcd backend so a restart of SkyDNS with the same unique value will give it access to the old data.
+That unique value is used as a path in etcd to store the values separately from
+the normal values. It is still stored in the etcd backend so a restart of SkyDNS
+with the same unique value will give it access to the old data.
 
 In the example here, we don't use an UUID, we use `public.addresses`:
 
@@ -438,16 +481,18 @@ In the example here, we don't use an UUID, we use `public.addresses`:
     local.dns.skydns.local. 3600 IN  A   192.0.2.1
 
 ## Implementing a custom DNS backend
-The SkyDNS `server` package may be used as a library, which allows a custom record
-retrieval implementation (referred to as a `Backend`) to be provided. The default
-Etcd implementation resides under `backends/etcd/etcd.go`. To provide your own
-backend implementation, you must implement the `server.Backend` interface.
+
+The SkyDNS `server` package may be used as a library, which allows a custom
+record retrieval implementation (referred to as a `Backend`) to be provided. The
+default Etcd implementation resides under `backends/etcd/etcd.go`. To provide
+your own backend implementation, you must implement the `server.Backend`
+interface.
 
 If you want to preserve the ability to answer arbitrary queries from etcd, but use
 your custom implementation for certain subsets of the namespace, the
 `server.FirstBackend` helper type will allow you to chain multiple `Backends` in
-order. The first backend that answers a `Records` or `ReverseRecord` call with a
-record and with no error will be served.
+order. The first backend that answers a `Records` or `ReverseRecord` call with
+a record and with no error will be served.
 
 # FAQ
 
@@ -455,8 +500,8 @@ record and with no error will be served.
 
 You have 3 machines with 3 different IP addresses and you want to have
 1 name pointing to all 3 possible addresses. The name we want to use is:
-`db.skydns.local` and the 3 addresses are 127.0.0.{1,2,3}. For this
-to work we create the hosts named `x{1,2,3}.db.skydns.local` in etcd:
+  `db.skydns.local` and the 3 addresses are 127.0.0.{1,2,3}. For this to work we
+  create the hosts named `x{1,2,3}.db.skydns.local` in etcd:
 
     curl -XPUT http://127.0.0.1:4001/v2/keys/skydns/local/skydns/db/x1 -d \
         value='{"Host":"127.0.0.1"}'
@@ -479,20 +524,19 @@ The MIT License (MIT)
 
 Copyright © 2014 The SkyDNS Authors
 
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software is furnished to do so,
+subject to the following conditions:
 
-The above copyright notice and this permission notice shall be included in
-all copies or substantial portions of the Software.
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
 
 THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
-THE SOFTWARE.
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -313,7 +313,7 @@ address to the additional section of the response:
     4.rails.staging.east.skydns.local. 3600 IN A    10.0.1.125
 
 Which conveys the same information and is legal in the DNS. To have some control on how
-the target names look you can register a service with `TargetStrip` set to a none-zero
+the target names look you can register a service with `TargetStrip` set to a non-zero
 value. This tells SkyDNS to strip `TargetStrip` labels from the left-side of the generated
 Target domain name. Support `TargetStrip` is 2 for this service, to above response would be:
 

--- a/README.md
+++ b/README.md
@@ -561,7 +561,7 @@ ports on bar.skydns.local and this name has IP addres 192.168.0.1:
     ;; ADDITIONAL SECTION:
     bar.skydns.local. 3600    IN  A   192.168.0.1
 
-So you register:
+So you register a "dummy" host named `x1`:
 
     curl -XPUT http://127.0.0.1:4001/v2/keys/skydns/local/skydns/bar/x1 -d \
         value='{"host":"192.168.0.1","port":80}'

--- a/README.md
+++ b/README.md
@@ -314,8 +314,7 @@ address to the additional section of the response:
 
 Which conveys the same information and is legal in the DNS. To have some control on how
 the target names look you can register a service with `TargetStrip` set to a non-zero
-value. This tells SkyDNS to strip `TargetStrip` labels from the left-side of the generated
-Target domain name. Support `TargetStrip` is 2 for this service, to above response would be:
+value. Setting TargetStrip to "2" strips 2 labels from the generated target name:
 
     ;; ANSWER SECTION:
     4.rails.staging.east.skydns.local 3600 IN SRV 10 100 staging.east.skydns.local.
@@ -323,6 +322,7 @@ Target domain name. Support `TargetStrip` is 2 for this service, to above respon
     ;; ADDITIONAL SECTION:
     staging.east.skydns.local. 3600 IN A    10.0.1.125
 
+Which removed the `4.rails` from the target name.
 
 #### A/AAAA Records
 To return A records, simply run a normal DNS query for a service matching the

--- a/msg/service.go
+++ b/msg/service.go
@@ -22,10 +22,13 @@ type Service struct {
 	Weight   int    `json:"weight,omitempty"`
 	Text     string `json:"text,omitempty"`
 	Ttl      uint32 `json:"ttl,omitempty"`
-	// When a SRV record with a "Host: IP-address" is added, we synthesize a srv.Target. Normally
-	// we convert the Key where the record lives to a DNS name and use this as the srv.Target.
-	// When TargetFromQuery is true we use the query name as the srv.Target.
-	TargetFromQuery bool `json:"targetfromquery",omitempty"`
+
+	// When a SRV record with a "Host: IP-address" is added, we synthesize a srv.Target
+	// domain name.
+	// Normally we convert the full Key where the record lives to a DNS name and use
+	// this as the srv.Target.
+	// When TargetStrip > 0 we strip the left most TargetStrip labels from the DNS name.
+	TargetStrip int `json:"targetstrip",omitempty"`
 
 	// Etcd key where we found this service and ignored from json un-/marshalling
 	Key string `json:"-"`
@@ -33,8 +36,20 @@ type Service struct {
 
 // NewSRV returns a new SRV record based on the Service.
 func (s *Service) NewSRV(name string, weight uint16) *dns.SRV {
+	host := dns.Fqdn(s.Host)
+
+	offset, end := 0, false
+	for i := 0; i < s.TargetStrip; i++ {
+		offset, end = dns.NextLabel(host, offset)
+	}
+	if end {
+		// We overshot the name, use the orignal one.
+		offset = 0
+	}
+	host = host[offset:]
+
 	return &dns.SRV{Hdr: dns.RR_Header{Name: name, Rrtype: dns.TypeSRV, Class: dns.ClassINET, Ttl: s.Ttl},
-		Priority: uint16(s.Priority), Weight: weight, Port: uint16(s.Port), Target: dns.Fqdn(s.Host)}
+		Priority: uint16(s.Priority), Weight: weight, Port: uint16(s.Port), Target: host}
 }
 
 // NewA returns a new A record based on the Service.

--- a/msg/service.go
+++ b/msg/service.go
@@ -22,7 +22,12 @@ type Service struct {
 	Weight   int    `json:"weight,omitempty"`
 	Text     string `json:"text,omitempty"`
 	Ttl      uint32 `json:"ttl,omitempty"`
-	// etcd key where we found this service and ignore from json un-/marshalling
+	// When a SRV record with a "Host: IP-address" is added, we synthesize a srv.Target. Normally
+	// we convert the Key where the record lives to a DNS name and use this as the srv.Target.
+	// When TargetFromQuery is true we use the query name as the srv.Target.
+	TargetFromQuery bool `json:"targetfromquery",omitempty"`
+
+	// Etcd key where we found this service and ignored from json un-/marshalling
 	Key string `json:"-"`
 }
 

--- a/server/forwarding.go
+++ b/server/forwarding.go
@@ -97,7 +97,7 @@ func (s *server) Lookup(n string, t, bufsize uint16, dnssec bool) (*dns.Msg, err
 		return nil, fmt.Errorf("no nameservers configured can not lookup name")
 	}
 	if dns.CountLabel(n) < s.config.Ndots {
-		return nil, fmt.Errorf("name has fewer than three labels")
+		return nil, fmt.Errorf("name has fewer than %d labels", s.config.Ndots)
 	}
 	m := new(dns.Msg)
 	m.SetQuestion(n, t)

--- a/server/server.go
+++ b/server/server.go
@@ -437,8 +437,7 @@ func (s *server) AddressRecords(q dns.Question, name string, previousRecords []d
 		ip := net.ParseIP(serv.Host)
 		switch {
 		case ip == nil:
-			// Try to resolve as CNAME if it's not an IP, but only is we don't
-			// create loops.
+			// Try to resolve as CNAME if it's not an IP, but only if we don't create loops.
 			if q.Name == dns.Fqdn(serv.Host) {
 				// x CNAME x is a direct loop, don't add those
 				continue

--- a/server/server.go
+++ b/server/server.go
@@ -574,19 +574,11 @@ func (s *server) SRVRecords(q dns.Question, name string, bufsize uint16, dnssec 
 			}
 			lookup[srv.Target] = true
 		case ip.To4() != nil:
-			if serv.TargetFromQuery {
-				serv.Host = q.Name
-			} else {
-				serv.Host = msg.Domain(serv.Key)
-			}
+			serv.Host = msg.Domain(serv.Key)
 			records = append(records, serv.NewSRV(q.Name, weight))
 			extra = append(extra, serv.NewA(serv.Host, ip.To4()))
 		case ip.To4() == nil:
-			if serv.TargetFromQuery {
-				serv.Host = q.Name
-			} else {
-				serv.Host = msg.Domain(serv.Key)
-			}
+			serv.Host = msg.Domain(serv.Key)
 			records = append(records, serv.NewSRV(q.Name, weight))
 			extra = append(extra, serv.NewAAAA(serv.Host, ip.To16()))
 		}

--- a/server/server.go
+++ b/server/server.go
@@ -291,6 +291,7 @@ func (s *server) ServeDNS(w dns.ResponseWriter, req *dns.Msg) {
 			m.Truncated = true
 		}
 		if err := w.WriteMsg(m); err != nil {
+				log.Printf("%s\n", m)
 			log.Printf("skydns: failure to return reply %q", err)
 		}
 	}()
@@ -574,12 +575,14 @@ func (s *server) SRVRecords(q dns.Question, name string, bufsize uint16, dnssec 
 			lookup[srv.Target] = true
 		case ip.To4() != nil:
 			// use the q.Name to synthesize the target of this SRV record
-			serv.Host = q.Name
+			serv.Host = msg.Domain(serv.Key)
+			//serv.Host = q.Name
 			records = append(records, serv.NewSRV(q.Name, weight))
 			extra = append(extra, serv.NewA(serv.Host, ip.To4()))
 		case ip.To4() == nil:
 			// use the q.Name to synthesize the target of this SRV record
-			serv.Host = q.Name
+			serv.Host = msg.Domain(serv.Key)
+			//serv.Host = q.Name
 			records = append(records, serv.NewSRV(q.Name, weight))
 			extra = append(extra, serv.NewAAAA(serv.Host, ip.To16()))
 		}

--- a/server/server.go
+++ b/server/server.go
@@ -20,7 +20,7 @@ import (
 	"github.com/skynetservices/skydns/msg"
 )
 
-const Version = "2.1.0a"
+const Version = "2.2.0a"
 
 type server struct {
 	backend Backend
@@ -366,42 +366,13 @@ func (s *server) ServeDNS(w dns.ResponseWriter, req *dns.Msg) {
 		m.Answer = append(m.Answer, records...)
 		m.Extra = append(m.Extra, extra...)
 	case dns.TypeA, dns.TypeAAAA:
-		records, err := s.AddressRecords(q, name, nil)
+		records, err := s.AddressRecords(q, name, nil, bufsize, dnssec)
 		if err != nil {
 			if e, ok := err.(*etcd.EtcdError); ok {
 				if e.ErrorCode == 100 {
 					s.NameError(m, req)
 					return
 				}
-			}
-			if err.Error() == "incomplete CNAME chain" {
-				// We can not complete the CNAME internally, *iff* there is a
-				// external name in the set, take it, and try to resolve it externally.
-				if len(records) == 0 {
-					s.NameError(m, req)
-					return
-				}
-				target := ""
-				for _, r := range records {
-					if v, ok := r.(*dns.CNAME); ok {
-						if !dns.IsSubDomain(s.config.Domain, v.Target) {
-							target = v.Target
-							break
-						}
-					}
-				}
-				if target == "" {
-					log.Printf("skydns: incomplete CNAME chain for %s", name)
-					s.NoDataError(m, req)
-					return
-				}
-				m1, e1 := s.Lookup(target, req.Question[0].Qtype, bufsize, dnssec)
-				if e1 != nil {
-					log.Printf("skydns: %s", err)
-					s.NoDataError(m, req)
-					return
-				}
-				records = append(records, m1.Answer...)
 			}
 		}
 		m.Answer = append(m.Answer, records...)
@@ -456,7 +427,7 @@ func (s *server) ServeDNS(w dns.ResponseWriter, req *dns.Msg) {
 	}
 }
 
-func (s *server) AddressRecords(q dns.Question, name string, previousRecords []dns.RR) (records []dns.RR, err error) {
+func (s *server) AddressRecords(q dns.Question, name string, previousRecords []dns.RR, bufsize uint16, dnssec bool) (records []dns.RR, err error) {
 	services, err := s.backend.Records(name, false)
 	if err != nil {
 		return nil, err
@@ -465,31 +436,47 @@ func (s *server) AddressRecords(q dns.Question, name string, previousRecords []d
 		ip := net.ParseIP(serv.Host)
 		switch {
 		case ip == nil:
-			/*
-			// TODO: deduplicate with above code
-			// Try to resolve as CNAME if it's not an IP.
+			// Try to resolve as CNAME if it's not an IP, but only is we don't
+			// create loops.
+			if q.Name == dns.Fqdn(serv.Host) {
+				// x CNAME x is a direct loop, don't add those
+				continue
+			}
+
 			newRecord := serv.NewCNAME(q.Name, dns.Fqdn(serv.Host))
 			if len(previousRecords) > 7 {
 				log.Printf("skydns: CNAME lookup limit of 8 exceeded for %s", newRecord)
-				return nil, fmt.Errorf("exceeded CNAME lookup limit")
+				// don't add it, and just continue
+				continue
 			}
 			if s.isDuplicateCNAME(newRecord, previousRecords) {
 				log.Printf("skydns: CNAME loop detected for record %s", newRecord)
-				return nil, fmt.Errorf("detected CNAME loop")
+				continue
 			}
 
 			records = append(records, newRecord)
-			nextRecords, err := s.AddressRecords(dns.Question{Name: dns.Fqdn(serv.Host), Qtype: q.Qtype, Qclass: q.Qclass}, strings.ToLower(dns.Fqdn(serv.Host)), append(previousRecords, newRecord))
-			if err != nil {
-				// This means we can not complete the CNAME, this is OK, but
-				// if we return an error this will trigger an NXDOMAIN.
-				// We also don't want to return the CNAME, because of the
-				// no other data rule. So return nothing and let NODATA
-				// kick in (via a hack).
-				return records, fmt.Errorf("incomplete CNAME chain")
+			nextRecords, err := s.AddressRecords(dns.Question{Name: dns.Fqdn(serv.Host), Qtype: q.Qtype, Qclass: q.Qclass},
+				strings.ToLower(dns.Fqdn(serv.Host)), append(previousRecords, newRecord), bufsize, dnssec)
+			if err == nil {
+				records = append(records, nextRecords...)
+				continue
 			}
-			records = append(records, nextRecords...)
-			*/
+			// This means we can not complete the CNAME, try to look else where.
+			target := newRecord.Target
+			if dns.IsSubDomain(s.config.Domain, target) {
+				// We should already have found it
+				continue
+			}
+			m1, e1 := s.Lookup(target, q.Qtype, bufsize, dnssec)
+			if e1 != nil {
+				log.Printf("skydns: %s", err)
+				continue
+			}
+			records = append(records, m1.Answer...)
+			continue
+
+			log.Printf("skydns: incomplete CNAME chain for %s", name)
+
 		case ip.To4() != nil && q.Qtype == dns.TypeA:
 			records = append(records, serv.NewA(q.Name, ip.To4()))
 		case ip.To4() == nil && q.Qtype == dns.TypeAAAA:

--- a/server/server.go
+++ b/server/server.go
@@ -291,7 +291,7 @@ func (s *server) ServeDNS(w dns.ResponseWriter, req *dns.Msg) {
 			m.Truncated = true
 		}
 		if err := w.WriteMsg(m); err != nil {
-				log.Printf("%s\n", m)
+			log.Printf("%s\n", m)
 			log.Printf("skydns: failure to return reply %q", err)
 		}
 	}()
@@ -574,15 +574,19 @@ func (s *server) SRVRecords(q dns.Question, name string, bufsize uint16, dnssec 
 			}
 			lookup[srv.Target] = true
 		case ip.To4() != nil:
-			// use the q.Name to synthesize the target of this SRV record
-			serv.Host = msg.Domain(serv.Key)
-			//serv.Host = q.Name
+			if serv.TargetFromQuery {
+				serv.Host = q.Name
+			} else {
+				serv.Host = msg.Domain(serv.Key)
+			}
 			records = append(records, serv.NewSRV(q.Name, weight))
 			extra = append(extra, serv.NewA(serv.Host, ip.To4()))
 		case ip.To4() == nil:
-			// use the q.Name to synthesize the target of this SRV record
-			serv.Host = msg.Domain(serv.Key)
-			//serv.Host = q.Name
+			if serv.TargetFromQuery {
+				serv.Host = q.Name
+			} else {
+				serv.Host = msg.Domain(serv.Key)
+			}
 			records = append(records, serv.NewSRV(q.Name, weight))
 			extra = append(extra, serv.NewAAAA(serv.Host, ip.To16()))
 		}

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -389,8 +389,8 @@ var services = []*msg.Service{
 	{Host: "server4", Priority: 30, Key: "104.server4.region5.skydns.test."},
 
 	// A name: bar.skydns.test with 2 ports open and points to one ip: 192.168.0.1
-	{Host: "192.168.0.1", Port: 80, Key: "x.bar.skydns.test."},
-	{Host: "bar.skydns.local", Port: 443, Key: "y.bar.skydns.test."},
+	{Host: "192.168.0.1", Port: 80, Key: "x.bar.skydns.test.", TargetFromQuery: true},
+	{Host: "bar.skydns.local", Port: 443, Key: "y.bar.skydns.test.", TargetFromQuery: true},
 
 	// nameserver
 	{Host: "10.0.0.2", Key: "ns.dns.skydns.test."},
@@ -769,10 +769,10 @@ var dnsTestCases = []dnsTestCase{
 		Answer: []dns.RR{
 			newSRV("bar.skydns.test. 3600 SRV 10 50 443 bar.skydns.local."),
 			// Issue 144 says x.bar.skydns.test should be bar.skydns.test
-			newSRV("bar.skydns.test. 3600 SRV 10 50 80 x.bar.skydns.test."),
+			newSRV("bar.skydns.test. 3600 SRV 10 50 80 bar.skydns.test."),
 		},
 		Extra: []dns.RR{
-			newA("x.bar.skydns.test. 3600 A 192.168.0.1"),
+			newA("bar.skydns.test. 3600 A 192.168.0.1"),
 		},
 	},
 }

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -389,8 +389,8 @@ var services = []*msg.Service{
 	{Host: "server4", Priority: 30, Key: "104.server4.region5.skydns.test."},
 
 	// A name: bar.skydns.test with 2 ports open and points to one ip: 192.168.0.1
-	{Host: "192.168.0.1", Port: 80, Key: "x.bar.skydns.test.", TargetFromQuery: true},
-	{Host: "bar.skydns.local", Port: 443, Key: "y.bar.skydns.test.", TargetFromQuery: true},
+	{Host: "192.168.0.1", Port: 80, Key: "x.bar.skydns.test.", TargetStrip: 1},
+	{Host: "bar.skydns.local", Port: 443, Key: "y.bar.skydns.test.", TargetStrip: 0},
 
 	// nameserver
 	{Host: "10.0.0.2", Key: "ns.dns.skydns.test."},

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -760,14 +760,19 @@ var dnsTestCases = []dnsTestCase{
 	{
 		Qname: "bar.skydns.test.", Qtype: dns.TypeA,
 		Answer: []dns.RR{
-
+			newA("bar.skydns.test. 3600 A 192.168.0.1"),
 		},
 	},
 	// Then ask for the SRV records.
 	{
 		Qname: "bar.skydns.test.", Qtype: dns.TypeSRV,
 		Answer: []dns.RR{
-
+			newSRV("bar.skydns.test. 3600 SRV 10 50 443 bar.skydns.local."),
+			// Issue 144 says x.bar.skydns.test should be bar.skydns.test
+			newSRV("bar.skydns.test. 3600 SRV 10 50 80 x.bar.skydns.test."),
+		},
+		Extra: []dns.RR{
+			newA("x.bar.skydns.test. 3600 A 192.168.0.1"),
 		},
 	},
 }

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -387,6 +387,11 @@ var services = []*msg.Service{
 	{Host: "server2", Weight: 80, Key: "101.server2.region5.skydns.test."},
 	{Host: "server3", Weight: 150, Key: "103.server3.region5.skydns.test."},
 	{Host: "server4", Priority: 30, Key: "104.server4.region5.skydns.test."},
+
+	// A name: bar.skydns.test with 2 ports open and points to one ip: 192.168.0.1
+	{Host: "192.168.0.1", Port: 80, Key: "x.bar.skydns.test."},
+	{Host: "bar.skydns.local", Port: 443, Key: "y.bar.skydns.test."},
+
 	// nameserver
 	{Host: "10.0.0.2", Key: "ns.dns.skydns.test."},
 	{Host: "10.0.0.3", Key: "ns2.dns.skydns.test."},
@@ -749,6 +754,21 @@ var dnsTestCases = []dnsTestCase{
 		Qname: "local.dns.skydns.test.", Qtype: dns.TypeA,
 		Rcode: dns.RcodeServerFailure,
 		chaos: true,
+	},
+
+	// One IP, two ports open, ask for the IP only.
+	{
+		Qname: "bar.skydns.test.", Qtype: dns.TypeA,
+		Answer: []dns.RR{
+
+		},
+	},
+	// Then ask for the SRV records.
+	{
+		Qname: "bar.skydns.test.", Qtype: dns.TypeSRV,
+		Answer: []dns.RR{
+
+		},
 	},
 }
 


### PR DESCRIPTION
From the README.md: 

If you ask for a service who's Host value is an IP address you would (in theory) get 
 back a SRV record such as: 
 
     % dig @localhost 4.rails.staging.east.skydns.local SRV
 
     ;; ANSWER SECTION:
     4.rails.staging.east.skydns.local 3600 IN SRV 10 100 8080 10.0.1.125
 
 Where the target of the SRV is an IP address. This is not how SRV records work.
 SkyDNS will in this case synthesize a domain name and add the actual IP
 address to the additional section of the response:
 
     % dig @localhost 4.rails.staging.east.skydns.local SRV
 
     ;; ANSWER SECTION:
     4.rails.staging.east.skydns.local 3600 IN SRV 10 100 4.rails.staging.east.skydns.local.
 
     ;; ADDITIONAL SECTION:
     4.rails.staging.east.skydns.local. 3600 IN A    10.0.1.125
 
 Which conveys the same information and is legal in the DNS. To have some control on how 
 the target names look you can register a service with `TargetStrip` set to a none-zero
 value. This tells SkyDNS to strip `TargetStrip` labels from the left-side of the generated
 Target domain name. Support `TargetStrip` is 2 for this service, to above response would be: 
 
     ;; ANSWER SECTION:
     4.rails.staging.east.skydns.local 3600 IN SRV 10 100 staging.east.skydns.local.
 
     ;; ADDITIONAL SECTION:
     staging.east.skydns.local. 3600 IN A    10.0.1.125
