### PR TITLE
Dedup responses

### DIFF
--- a/server/server.go
+++ b/server/server.go
@@ -9,6 +9,7 @@ import (
 	"log"
 	"math"
 	"net"
+	"strconv"
 	"strings"
 	"sync"
 	"time"
@@ -262,7 +263,10 @@ func (s *server) ServeDNS(w dns.ResponseWriter, req *dns.Msg) {
 			}
 			return
 		}
-		// Set TTL to the minimum of the RRset.
+		// Set TTL to the minimum of the RRset and dedup the message, i.e.
+		// remove idential RRs.
+		m = dedup(m)
+
 		minttl := s.config.Ttl
 		if len(m.Answer) > 1 {
 			for _, r := range m.Answer {
@@ -710,4 +714,54 @@ func (s *server) RoundRobin(rrs []dns.RR) {
 		}
 	}
 
+}
+
+// dedup will de-duplicate a message on a per section basis.
+// Multiple identical (same name, class, type and rdata) RRs will be coalesced into one.
+func dedup(m *dns.Msg) *dns.Msg {
+	// Answer section
+	ma := make(map[string]dns.RR)
+	for _, a := range m.Answer {
+		// Or use Pack()... Think this function also could be places in go dns.
+		s := a.Header().Name
+		s += strconv.Itoa(int(a.Header().Class))
+		s += strconv.Itoa(int(a.Header().Rrtype))
+		for i := 1; i <= dns.NumField(a); i++ {
+			s += dns.Field(a, i)
+		}
+		ma[s] = a
+	}
+	// Only is our map is smaller than the #RR in the answer section we should reset the RRs
+	// in the section it self
+	if len(ma) < len(m.Answer) {
+		i := 0
+		for _, v := range ma {
+			m.Answer[i] = v
+			i++
+		}
+		m.Answer = m.Answer[:len(ma)]
+	}
+
+	// Additional section
+	me := make(map[string]dns.RR)
+	for _, e := range m.Extra {
+		s := e.Header().Name
+		s += strconv.Itoa(int(e.Header().Class))
+		s += strconv.Itoa(int(e.Header().Rrtype))
+		for i := 1; i <= dns.NumField(e); i++ {
+			s += dns.Field(e, i)
+		}
+		me[s] = e
+	}
+
+	if len(me) < len(m.Extra) {
+		i := 0
+		for _, v := range me {
+			m.Extra[i] = v
+			i++
+		}
+		m.Extra = m.Extra[:len(me)]
+	}
+
+	return m
 }

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -777,6 +777,27 @@ func newNSEC3(rr string) *dns.NSEC3   { r, _ := dns.NewRR(rr); return r.(*dns.NS
 func newPTR(rr string) *dns.PTR       { r, _ := dns.NewRR(rr); return r.(*dns.PTR) }
 func newTXT(rr string) *dns.TXT       { r, _ := dns.NewRR(rr); return r.(*dns.TXT) }
 
+func TestDedup(t *testing.T) {
+	m := new(dns.Msg)
+	m.Answer = []dns.RR{
+		newA("svc.ns.kubernetes.local. IN A 3.3.3.3"),
+		newA("svc.ns.kubernetes.local. IN A 2.2.2.2"),
+		newA("svc.ns.kubernetes.local. IN A 3.3.3.3"),
+		newA("svc.ns.kubernetes.local. IN A 2.2.2.2"),
+		newA("svc.ns.kubernetes.local. IN A 1.1.1.1"),
+		newA("svc.ns.kubernetes.local. IN A 1.1.1.1"),
+	}
+	m = dedup(m)
+	sort.Sort(rrSet(m.Answer))
+	if len(m.Answer) != 3 {
+		t.Fatalf("failing dedup: should have collapsed it to 3 records")
+	}
+	if dns.Field(m.Answer[0], 1) != "1.1.1.1" || dns.Field(m.Answer[1], 1) != "2.2.2.2" ||
+		dns.Field(m.Answer[2], 1) != "3.3.3.3" {
+		t.Fatalf("failing dedup: %s", m)
+	}
+}
+
 func BenchmarkDNSSingleCache(b *testing.B) {
 	b.StopTimer()
 	t := new(testing.T)

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -393,6 +393,9 @@ var services = []*msg.Service{
 	// txt
 	{Text: "abc", Key: "a1.txt.skydns.test."},
 	{Text: "abc abc", Key: "a2.txt.skydns.test."},
+	// duplicate ip address
+	{Host: "10.11.11.10", Key: "http.multiport.http.skydns.test.", Port: 80},
+	{Host: "10.11.11.10", Key: "https.multiport.http.skydns.test.", Port: 443},
 }
 
 var dnsTestCases = []dnsTestCase{
@@ -754,6 +757,11 @@ var dnsTestCases = []dnsTestCase{
 	{
 		Qname: "skydns.test.", Qtype: dns.TypeHINFO,
 		Ns: []dns.RR{newSOA("skydns.test. 3600 SOA ns.dns.skydns.test. hostmaster.skydns.test. 0 0 0 0 0")},
+	},
+	// Duplicate IP address test
+	{
+		Qname: "multiport.http.skydns.test.", Qtype: dns.TypeA,
+		Answer: []dns.RR{newA("multiport.http.skydns.test. IN A 10.11.11.10")},
 	},
 }
 


### PR DESCRIPTION
Multiple idential RR records should be dedupped so that only one is
left.
I.e.

multiport.th1.kubernetes.local. 3600 IN A   1.1.1.1
multiport.th1.kubernetes.local. 3600 IN A   1.1.1.1

Should return:

multiport.th1.kubernetes.local. 3600 IN A   1.1.1.1

Note: I believe the clients don't really care about this and stuff just
works, but a good server should not be sending out invalid messages.

Also added test case that checks for this. We also dedup the additional
section, but for now there is no test for this.

Fixes #149