### PR TITLE
Stubzones

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,3 +14,4 @@ install:
 before_script:
   - go build -o $HOME/gopath/src/github.com/coreos/etcd/etcd.run github.com/coreos/etcd
   - $HOME/gopath/src/github.com/coreos/etcd/etcd.run &
+  - sleep 2

--- a/README.md
+++ b/README.md
@@ -568,6 +568,8 @@ When SkyDNS reveives a query for `skydns.com` it will *not* forward it to the re
 instead will query 172.16.1.1 on port 54 and if that fails will query 10.10.244.1 (on 53) to get
 an answer. That answer will then given back to the original client.
 
+DO NOT. I repeat *DO NOT* forward from one SkyDNS instance to another.
+
 # FAQ
 
 

--- a/README.md
+++ b/README.md
@@ -546,7 +546,7 @@ example shows on how to set this up. Suppose we want to create a stub zone for
 
 * 172.16.1.1, port 54
 * 10.10.244.1, port 53 (53 is the default that will be used if there isn't one
-    specificed)
+    specified)
 
 We should then register 2 services under the name `skydns.com.stub.dns.skydns.local`
 
@@ -555,7 +555,7 @@ We should then register 2 services under the name `skydns.com.stub.dns.skydns.lo
     % curl -XPUT http://127.0.0.1:4001/v2/keys/skydns/local/skydns/dns/stub/com/skydns/ns2 \
         -d value='{"host":"10.10.244.1"}'
 
-So the leaves should have the nameserver information.
+So the *leaves* should have the nameserver information.
 
     xxx.<domain name>.stub.dns.skydns.local
     |           |
@@ -564,13 +564,15 @@ So the leaves should have the nameserver information.
                 v
           stub domain name
 
-When SkyDNS reveives a query for `skydns.com` it will *not* forward it to the recursors, but
-instead will query 172.16.1.1 on port 54 and if that fails will query 10.10.244.1 (on 53) to get
-an answer. That answer will then given back to the original client.
+When SkyDNS receives a query for `skydns.com` it will *not* forward it to the
+recursors, but instead will query 172.16.1.1 on port 54 and if that fails will
+query 10.10.244.1 (on 53) to get an answer. That answer will then be given back
+to the original client.
 
-DO NOT. I repeat *DO NOT* forward from one SkyDNS instance to another.
-
-# FAQ
+When forwarding to a stub, SkyDNS adds a EDNS0 meta data RR to the packet
+telling the remote server (if its a SkyDNS instance) that this is a stub request.
+SkyDNS will not (stub)forward packets with this EDNS0 meta data, instead the request
+will be dropped and logged.
 
 
 ## How Do I Create an Address Pool and Round Robin Between Them

--- a/README.md
+++ b/README.md
@@ -536,7 +536,8 @@ Stub Zones are pointers that point to *another set* of servers which should
 provide an answer for the current query. This is similar to the (recursive)
 forwarding SkyDNS does, but different in that you need to specify a domain name
 and a set of authoritative servers. Also this can be dynamically controlled by
-writing values into Etcd.
+writing values into Etcd. Note, that when enabled SkyDNS will *first* consult
+the stub configuration, potentially bypassing any configured local records.
 
 The stub zone configuration lives under `stub.dns.skydns.local.`. The following
 example shows on how to set this up. Suppose we want to create a stub zone for

--- a/README.md
+++ b/README.md
@@ -530,6 +530,43 @@ order. The first backend that answers a `Records` or `ReverseRecord` call with
 a record and with no error will be served.
 
 
+## Stub Zones
+
+Stub Zones are pointers that point to *another set* of servers which should
+provide an answer for the current query. This is similar to the (recursive)
+forwarding SkyDNS does, but different in that you need to specify a domain name
+and a set of authoritative servers. Also this can be dynamically controlled by
+writing values into Etcd.
+
+The stub zone configuration lives under `stub.dns.skydns.local.`. The following
+example shows on how to set this up. Suppose we want to create a stub zone for
+`skydns.com` and point to the nameservers reachable by following address *and*
+(optional) ports:
+
+* 172.16.1.1, port 54
+* 10.10.244.1, port 53 (53 is the default that will be used if there isn't one
+    specificed)
+
+We should then register 2 services under the name `skydns.com.stub.dns.skydns.local`
+
+    % curl -XPUT http://127.0.0.1:4001/v2/keys/skydns/local/skydns/dns/stub/com/skydns/ns1 \
+        -d value='{"host":"172.16.1.1", "port":54}'
+    % curl -XPUT http://127.0.0.1:4001/v2/keys/skydns/local/skydns/dns/stub/com/skydns/ns2 \
+        -d value='{"host":"10.10.244.1"}'
+
+So the leaves should have the nameserver information.
+
+    xxx.<domain name>.stub.dns.skydns.local
+    |           |
+    v           |
+    nameservers |
+                v
+          stub domain name
+
+When SkyDNS reveives a query for `skydns.com` it will *not* forward it to the recursors, but
+instead will query 172.16.1.1 on port 54 and if that fails will query 10.10.244.1 (on 53) to get
+an answer. That answer will then given back to the original client.
+
 # FAQ
 
 

--- a/README.md
+++ b/README.md
@@ -636,12 +636,15 @@ it makes up:
 
 
 # Docker
+
 Official Docker images are at the [Docker Hub](https://registry.hub.docker.com/u/skynetservices/skydns/):
 
 * master -> skynetservices/skydns:latest
 * latest tag -> skynetservices/skydns:latest-tagged
 
+
 # License
+
 The MIT License (MIT)
 
 Copyright © 2014 The SkyDNS Authors

--- a/main.go
+++ b/main.go
@@ -143,7 +143,7 @@ func main() {
 						duration = 1 * time.Second // reset
 					} else {
 						// we can see an n == nil, probably when we can't connect to etcd.
-						log.Printf("skydns: ectd stubzone update failed, sleeping %s + ~3s", duration)
+						log.Printf("skydns: stubzone update failed, sleeping %s + ~3s", duration)
 						time.Sleep(duration + (time.Duration(rand.Float32() * 3e9))) // Add some random.
 						duration *= 2
 						if duration > 32*time.Second {

--- a/server/config.go
+++ b/server/config.go
@@ -63,6 +63,10 @@ type Config struct {
 	// some predefined string "constants"
 	localDomain string // "local.dns." + config.Domain
 	dnsDomain   string // "dns". + config.Domain
+
+	// Stub zones support. Pointer to a map that we refresh when we see
+	// an update. Map contains domainname -> nameserver:port
+	stub *map[string][]string
 }
 
 func SetDefaults(config *Config) error {
@@ -130,6 +134,8 @@ func SetDefaults(config *Config) error {
 	}
 	config.localDomain = appendDomain("local.dns", config.Domain)
 	config.dnsDomain = appendDomain("dns", config.Domain)
+	stubmap := make(map[string][]string)
+	config.stub = &stubmap
 	return nil
 }
 

--- a/server/server.go
+++ b/server/server.go
@@ -240,6 +240,15 @@ func (s *server) ServeDNS(w dns.ResponseWriter, req *dns.Msg) {
 	if s.config.Verbose {
 		log.Printf("skydns: received DNS Request for %q from %q with type %d", q.Name, w.RemoteAddr(), q.Qtype)
 	}
+
+	for zone, ns := range *s.config.stub {
+		// or dns.IsSubDomain
+		if dns.IsSubDomain(zone, name) {
+			s.ServeDNSStubForward(w, req, ns)
+			return
+		}
+	}
+
 	// If the qname is local.dns.skydns.local. and s.config.Local != "", substitute that name.
 	if s.config.Local != "" && name == s.config.localDomain {
 		name = s.config.Local

--- a/server/server.go
+++ b/server/server.go
@@ -242,8 +242,7 @@ func (s *server) ServeDNS(w dns.ResponseWriter, req *dns.Msg) {
 	}
 
 	for zone, ns := range *s.config.stub {
-		// or dns.IsSubDomain
-		if dns.IsSubDomain(zone, name) {
+		if strings.HasSuffix(name, zone) {
 			s.ServeDNSStubForward(w, req, ns)
 			return
 		}

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -126,7 +126,7 @@ func TestDNSForward(t *testing.T) {
 		}
 	}
 	if len(resp.Answer) == 0 || resp.Rcode != dns.RcodeSuccess {
-		t.Fatal("Answer expected to have A records or rcode not equal to RcodeSuccess")
+		t.Fatal("answer expected to have A records or rcode not equal to RcodeSuccess")
 	}
 	// TCP
 	c.Net = "tcp"
@@ -135,9 +135,57 @@ func TestDNSForward(t *testing.T) {
 		t.Fatal(err)
 	}
 	if len(resp.Answer) == 0 || resp.Rcode != dns.RcodeSuccess {
-		t.Fatal("Answer expected to have A records or rcode not equal to RcodeSuccess")
+		t.Fatal("answer expected to have A records or rcode not equal to RcodeSuccess")
 	}
 }
+
+func TestDNSStubForward(t *testing.T) {
+	s := newTestServer(t, false)
+	defer s.Stop()
+
+	c := new(dns.Client)
+	m := new(dns.Msg)
+
+	stubEx := &msg.Service{
+		// IP address of a.iana-servers.net.
+		Host: "199.43.132.53", Key: "a.example.com.stub.dns.skydns.test.",
+	}
+	stubBroken := &msg.Service{
+		Host: "127.0.0.1", Port: 5454, Key: "b.example.org.stub.dns.skydns.test.",
+	}
+	addService(t, s, stubEx.Key, 0, stubEx)
+	defer delService(t, s, stubEx.Key)
+	addService(t, s, stubBroken.Key, 0, stubBroken)
+	defer delService(t, s, stubBroken.Key)
+
+	s.UpdateStubZones()
+
+	m.SetQuestion("www.example.com.", dns.TypeA)
+	resp, _, err := c.Exchange(m, "127.0.0.1:"+StrPort)
+	if err != nil {
+		// try twice
+		resp, _, err = c.Exchange(m, "127.0.0.1:"+StrPort)
+		if err != nil {
+			t.Fatal(err)
+		}
+	}
+	if len(resp.Answer) == 0 || resp.Rcode != dns.RcodeSuccess {
+		t.Fatal("answer expected to have A records or rcode not equal to RcodeSuccess")
+	}
+	// The main diff. here is that we expect the AA bit to be set, because we directly
+	// queried the authoritative servers.
+	if resp.Authoritative != true {
+		t.Fatal("answer expected to have AA bit set")
+	}
+
+	// This should fail.
+	m.SetQuestion("www.example.org.", dns.TypeA)
+	resp, _, err = c.Exchange(m, "127.0.0.1:"+StrPort)
+	if len(resp.Answer) != 0 || resp.Rcode != dns.RcodeServerFailure {
+		t.Fatal("answer expected to fail")
+	}
+}
+
 func TestDNSTtlRRset(t *testing.T) {
 	s := newTestServerDNSSEC(t, false)
 	defer s.Stop()

--- a/server/stats.go
+++ b/server/stats.go
@@ -15,11 +15,12 @@ func (nopCounter) Inc(_ int64) {}
 
 // These are the stat variables defined by this package.
 var (
-	StatsForwardCount    Counter = nopCounter{}
-	StatsLookupCount     Counter = nopCounter{}
-	StatsRequestCount    Counter = nopCounter{}
-	StatsDnssecOkCount   Counter = nopCounter{}
-	StatsDnssecCacheMiss Counter = nopCounter{}
-	StatsNameErrorCount  Counter = nopCounter{}
-	StatsNoDataCount     Counter = nopCounter{}
+	StatsForwardCount     Counter = nopCounter{}
+	StatsStubForwardCount Counter = nopCounter{}
+	StatsLookupCount      Counter = nopCounter{}
+	StatsRequestCount     Counter = nopCounter{}
+	StatsDnssecOkCount    Counter = nopCounter{}
+	StatsDnssecCacheMiss  Counter = nopCounter{}
+	StatsNameErrorCount   Counter = nopCounter{}
+	StatsNoDataCount      Counter = nopCounter{}
 )

--- a/server/stub.go
+++ b/server/stub.go
@@ -11,7 +11,7 @@ import (
 	"strings"
 
 	"github.com/miekg/dns"
-	"github.com/miekg/skydns/msg"
+	"github.com/skynetservices/skydns/msg"
 )
 
 // Look in .../dns/stub/<domain>/xx for msg.Services. Loop through them

--- a/server/stub.go
+++ b/server/stub.go
@@ -5,6 +5,7 @@
 package server
 
 import (
+	"fmt"
 	"log"
 	"net"
 
@@ -13,13 +14,22 @@ import (
 
 // Look in .../dns/stub/<domain>/xx for msg.Services. Loop through them
 // extract <domain> and add them as forwarders (ip:port-combos) for
-// the stubzones.
+// the stubzones. Hosts that point to names will not be used.
 func (s *server) UpdateStubZones() {
 	// do some fakery here in the beginning
 	stubmap := make(map[string][]string)
 	stubmap["miek.nl."] = []string{"172.16.0.1:54", "176.58.119.54:53"}
 
 	// We can just uses the backend interface to get these records.
+	services, err := s.backend.Records("stub.dns."+s.config.Domain, false)
+	if err != nil {
+		log.Printf("skydns: stubzone update failed: %s", err)
+		return
+	}
+	for _, serv := range services {
+		fmt.Printf("%+v\n", serv)
+		//		ip := net.ParseIP(serv.Host)
+	}
 
 	s.config.stub = &stubmap
 }

--- a/server/stub.go
+++ b/server/stub.go
@@ -31,13 +31,13 @@ var ednsStub = func() *dns.OPT {
 
 // Look in .../dns/stub/<domain>/xx for msg.Services. Loop through them
 // extract <domain> and add them as forwarders (ip:port-combos) for
-// the stubzones. Only numeric (i.e. IP address) hosts are used.
+// the stub zones. Only numeric (i.e. IP address) hosts are used.
 func (s *server) UpdateStubZones() {
 	stubmap := make(map[string][]string)
 
 	services, err := s.backend.Records("stub.dns."+s.config.Domain, false)
 	if err != nil {
-		log.Printf("skydns: stubzone update failed: %s", err)
+		log.Printf("skydns: stub zone update failed: %s", err)
 		return
 	}
 	for _, serv := range services {
@@ -46,7 +46,7 @@ func (s *server) UpdateStubZones() {
 		}
 		ip := net.ParseIP(serv.Host)
 		if ip == nil {
-			log.Printf("skydns: stubzone non-address %s seen for: %s", serv.Key, serv.Host)
+			log.Printf("skydns: stub zone non-address %s seen for: %s", serv.Key, serv.Host)
 			continue
 		}
 

--- a/server/stub.go
+++ b/server/stub.go
@@ -6,6 +6,7 @@ package server
 
 import (
 	"log"
+	"net"
 
 	"github.com/miekg/dns"
 )
@@ -25,6 +26,46 @@ func (s *server) UpdateStubZones() {
 
 // ServeDNSForward forwards a request to a nameservers and returns the response.
 func (s *server) ServeDNSStubForward(w dns.ResponseWriter, req *dns.Msg, ns []string) {
-	// StatsStubForwardcount.Inc(1)
-	log.Printf("skydns: stub zone forward")
+	StatsStubForwardCount.Inc(1)
+
+	// Very similar to ServeDNSForward. Maybe refactor them both.
+
+	tcp := false
+	if _, ok := w.RemoteAddr().(*net.TCPAddr); ok {
+		tcp = true
+	}
+
+	var (
+		r   *dns.Msg
+		err error
+		try int
+	)
+	// Use request Id for "random" nameserver selection.
+	nsid := int(req.Id) % len(ns)
+Redo:
+	switch tcp {
+	case false:
+		r, _, err = s.dnsUDPclient.Exchange(req, ns[nsid])
+	case true:
+		r, _, err = s.dnsTCPclient.Exchange(req, ns[nsid])
+	}
+	if err == nil {
+		r.Compress = true
+		r.Id = req.Id
+		w.WriteMsg(r)
+		return
+	}
+	// Seen an error, this can only mean, "server not reached", try again
+	// but only if we have not exausted our nameservers.
+	if try < len(ns) {
+		try++
+		nsid = (nsid + 1) % len(ns)
+		goto Redo
+	}
+
+	log.Printf("skydns: failure to forward stub request %q", err)
+	m := new(dns.Msg)
+	m.SetReply(req)
+	m.SetRcode(req, dns.RcodeServerFailure)
+	w.WriteMsg(m)
 }

--- a/server/stub.go
+++ b/server/stub.go
@@ -1,0 +1,30 @@
+// Copyright (c) 2014 The SkyDNS Authors. All rights reserved.
+// Use of this source code is governed by The MIT License (MIT) that can be
+// found in the LICENSE file.
+
+package server
+
+import (
+	"log"
+
+	"github.com/miekg/dns"
+)
+
+// Look in .../dns/stub/<domain>/xx for msg.Services. Loop through them
+// extract <domain> and add them as forwarders (ip:port-combos) for
+// the stubzones.
+func (s *server) UpdateStubZones() {
+	// do some fakery here in the beginning
+	stubmap := make(map[string][]string)
+	stubmap["miek.nl."] = []string{"172.16.0.1:54", "176.58.119.54:53"}
+
+	// We can just uses the backend interface to get these records.
+
+	s.config.stub = &stubmap
+}
+
+// ServeDNSForward forwards a request to a nameservers and returns the response.
+func (s *server) ServeDNSStubForward(w dns.ResponseWriter, req *dns.Msg, ns []string) {
+	// StatsStubForwardcount.Inc(1)
+	log.Printf("skydns: stub zone forward")
+}

--- a/server/stub.go
+++ b/server/stub.go
@@ -56,7 +56,7 @@ func (s *server) UpdateStubZones() {
 		labels := dns.SplitDomainName(domain)
 		domain = dns.Fqdn(strings.Join(labels[1:len(labels)-dns.CountLabel(s.config.localDomain)], "."))
 
-		// if domain if the remaining name equals s.config.LocalDomain we ignore it.
+		// If the remaining name equals s.config.LocalDomain we ignore it.
 		if domain == s.config.localDomain {
 			log.Printf("skydns: not adding stub zone for my own domain")
 			continue
@@ -67,7 +67,7 @@ func (s *server) UpdateStubZones() {
 	s.config.stub = &stubmap
 }
 
-// ServeDNSForward forwards a request to a nameservers and returns the response.
+// ServeDNSStubForward forwards a request to a nameservers and returns the response.
 func (s *server) ServeDNSStubForward(w dns.ResponseWriter, req *dns.Msg, ns []string) {
 	StatsStubForwardCount.Inc(1)
 

--- a/stats/graphite.go
+++ b/stats/graphite.go
@@ -31,6 +31,9 @@ func init() {
 	server.StatsForwardCount = metrics.NewCounter()
 	metrics.Register("skydns-forward-requests", server.StatsForwardCount)
 
+	server.StatsStubForwardCount = metrics.NewCounter()
+	metrics.Register("skydns-stub-forward-requests", server.StatsStubForwardCount)
+
 	server.StatsDnssecOkCount = metrics.NewCounter()
 	metrics.Register("skydns-dnssecok-requests", server.StatsDnssecOkCount)
 


### PR DESCRIPTION
Stub Zones are pointers that point to *another set* of servers which should
provide an answer for the current query. This is similar to the (recursive)
forwarding SkyDNS does, but different in that you need to specify a domain name
and a set of authoritative servers. Also this can be dynamically controlled by
writing values into Etcd. Note, that when enabled SkyDNS will *first* consult
the stub configuration, potentially bypassing any configured local records.

The configuration is stored under `stub.dns.skydns.local`.