### PR TITLE
Dockerfile updates

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,10 @@
-FROM crosbymichael/golang
+FROM google/debian:wheezy
 MAINTAINER Miek Gieben <miek@miek.nl> (@miekg)
 
 RUN apt-get update && apt-get install --no-install-recommends -y \
     dnsutils
 
-ADD . /go/src/github.com/skynetservices/skydns
-RUN go get github.com/skynetservices/skydns
+ADD skydns skydns
 
 EXPOSE 53 53/udp
-ENTRYPOINT ["skydns"]
+ENTRYPOINT ["/skydns"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,7 @@
-FROM google/debian:wheezy
+FROM accursoft/micro-jessie
 MAINTAINER Miek Gieben <miek@miek.nl> (@miekg)
 
-RUN apt-get update && apt-get install --no-install-recommends -y \
-    dnsutils
+RUN apt-get update && apt-get install --no-install-recommends -y dnsutils
 
 ADD skydns skydns
 

--- a/README.md
+++ b/README.md
@@ -654,6 +654,11 @@ Official Docker images are at the [Docker Hub](https://registry.hub.docker.com/u
 * master -> skynetservices/skydns:latest
 * latest tag -> skynetservices/skydns:latest-tagged
 
+The supplied `Dockerfile` can be used to build an image as well. Build SkyDNS and then
+build the docker image:
+
+    % go build
+    % docker build -t $USER/skydns .
 
 # License
 


### PR DESCRIPTION
Create a smaller Dockerfile that just copies the static binary
in the image. No need to ship the *entire* golang build infrastructure
in an image.

Added some docs on how to locally build.