### PR TITLE
Base image of progrium/busybox

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
-FROM accursoft/micro-jessie
+FROM progrium/busybox
 MAINTAINER Miek Gieben <miek@miek.nl> (@miekg)
 
-RUN apt-get update && apt-get install --no-install-recommends -y dnsutils
+RUN opkg-install bind-dig
 
 ADD skydns skydns
 


### PR DESCRIPTION
Using a busybox only is annoying because there isn't a good dig
equiv. Having access to packages, in this case openwrt, makes sense
because it makes live much easier.

Total size is 15.13 MB.