### PR TITLE
Add MX record support.

### DIFF
--- a/README.md
+++ b/README.md
@@ -345,6 +345,11 @@ listed, so this is only useful when you're querying for services running on
 ports known to you in advance.
 
 
+#### MX Records
+
+Some text about MX records here.
+
+
 #### CNAME Records
 If for an A or AAAA query the IP address can not be parsed, SkyDNS will try to
 see if there is a chain of names that will lead to an IP address. The chain can

--- a/README.md
+++ b/README.md
@@ -347,10 +347,12 @@ ports known to you in advance.
 
 #### MX Records
 
-Some text about MX records here.
+If a service is added with `"mail": true` it is *also* an MX record, the Priority
+doubles as the MX's Preference.
 
 
 #### CNAME Records
+
 If for an A or AAAA query the IP address can not be parsed, SkyDNS will try to
 see if there is a chain of names that will lead to an IP address. The chain can
 not be longer than 8. So for instance if the following services have been

--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ here](https://github.com/skynetservices/skydns1).
 
 
 ## Setup / Install
+
 Download/compile and run etcd. See the documentation for etcd at <https://github.com/coreos/etcd>.
 
 Then get and compile SkyDNS:
@@ -163,7 +164,8 @@ values.
 * TTL - the time-to-live of the service, overriding the default TTL. If the etcd
   key also has a TTL, the minimum of this value and the etcd TTL is used.
 
-Path is the only mandatory field.
+Path is the only mandatory field. The lookups into Etcd will be done with
+a *lower* cased path name.
 
 Adding the service can thus be done with:
 

--- a/msg/service.go
+++ b/msg/service.go
@@ -54,7 +54,7 @@ func (s *Service) NewSRV(name string, weight uint16) *dns.SRV {
 }
 
 // NewMX returns a new MX record based on the Service.
-func (s *Service) NewMX(name string, weight uint16) *dns.MX {
+func (s *Service) NewMX(name string) *dns.MX {
 	host := dns.Fqdn(s.Host)
 
 	offset, end := 0, false

--- a/server/server.go
+++ b/server/server.go
@@ -411,6 +411,18 @@ func (s *server) ServeDNS(w dns.ResponseWriter, req *dns.Msg) {
 			}
 		}
 		m.Answer = append(m.Answer, records...)
+	case dns.TypeMX:
+		records, extra, err := s.MXRecords(q, name, bufsize, dnssec)
+		if err != nil {
+			if e, ok := err.(*etcd.EtcdError); ok {
+				if e.ErrorCode == 100 {
+					s.NameError(m, req)
+					return
+				}
+			}
+		}
+		m.Answer = append(m.Answer, records...)
+		m.Extra = append(m.Extra, extra...)
 	default:
 		fallthrough // also catch other types, so that they return NODATA
 	case dns.TypeSRV:
@@ -532,7 +544,7 @@ func (s *server) NSRecords(q dns.Question, name string) (records []dns.RR, extra
 }
 
 // SRVRecords returns SRV records from etcd.
-// If the Target is not an name but an IP address, a name is created.
+// If the Target is not a name but an IP address, a name is created.
 func (s *server) SRVRecords(q dns.Question, name string, bufsize uint16, dnssec bool) (records []dns.RR, extra []dns.RR, err error) {
 	services, err := s.backend.Records(name, false)
 	if err != nil {
@@ -604,6 +616,55 @@ func (s *server) SRVRecords(q dns.Question, name string, bufsize uint16, dnssec 
 		case ip.To4() == nil:
 			serv.Host = msg.Domain(serv.Key)
 			records = append(records, serv.NewSRV(q.Name, weight))
+			extra = append(extra, serv.NewAAAA(serv.Host, ip.To16()))
+		}
+	}
+	return records, extra, nil
+}
+
+// MXRecords returns MX records from etcd.
+// If the Target is not a name but an IP address, a name is created.
+func (s *server) MXRecords(q dns.Question, name string, bufsize uint16, dnssec bool) (records []dns.RR, extra []dns.RR, err error) {
+	services, err := s.backend.Records(name, false)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	lookup := make(map[string]bool)
+	for _, serv := range services {
+		if !serv.Mail {
+			continue
+		}
+		ip := net.ParseIP(serv.Host)
+		switch {
+		case ip == nil:
+			mx := serv.NewMX(q.Name)
+			records = append(records, mx)
+			if _, ok := lookup[mx.Mx]; !ok {
+				if !dns.IsSubDomain(s.config.Domain, mx.Mx) {
+					m1, e1 := s.Lookup(mx.Mx, dns.TypeA, bufsize, dnssec)
+					if e1 == nil {
+						extra = append(extra, m1.Answer...)
+					}
+					m1, e1 = s.Lookup(mx.Mx, dns.TypeAAAA, bufsize, dnssec)
+					if e1 == nil {
+						// If we have seen CNAME's we *assume* that they are already added.
+						for _, a := range m1.Answer {
+							if _, ok := a.(*dns.CNAME); !ok {
+								extra = append(extra, a)
+							}
+						}
+					}
+				}
+			}
+			lookup[mx.Mx] = true
+		case ip.To4() != nil:
+			serv.Host = msg.Domain(serv.Key)
+			records = append(records, serv.NewMX(q.Name))
+			extra = append(extra, serv.NewA(serv.Host, ip.To4()))
+		case ip.To4() == nil:
+			serv.Host = msg.Domain(serv.Key)
+			records = append(records, serv.NewMX(q.Name))
 			extra = append(extra, serv.NewAAAA(serv.Host, ip.To16()))
 		}
 	}

--- a/server/server.go
+++ b/server/server.go
@@ -532,7 +532,7 @@ func (s *server) NSRecords(q dns.Question, name string) (records []dns.RR, extra
 }
 
 // SRVRecords returns SRV records from etcd.
-// If the Target is not an name but an IP address, an name is created .
+// If the Target is not an name but an IP address, a name is created.
 func (s *server) SRVRecords(q dns.Question, name string, bufsize uint16, dnssec bool) (records []dns.RR, extra []dns.RR, err error) {
 	services, err := s.backend.Records(name, false)
 	if err != nil {
@@ -647,9 +647,9 @@ func (s *server) PTRRecords(q dns.Question) (records []dns.RR, err error) {
 		return nil, err
 	}
 
-	// If serv.Host is parseble as a IP address we should not return anything.
-	// TODO(miek).
-	records = append(records, serv.NewPTR(q.Name, serv.Ttl))
+	if ip := net.ParseIP(serv.Host); ip != nil {
+		records = append(records, serv.NewPTR(q.Name, serv.Ttl))
+	}
 	return records, nil
 }
 

--- a/server/server.go
+++ b/server/server.go
@@ -647,9 +647,7 @@ func (s *server) PTRRecords(q dns.Question) (records []dns.RR, err error) {
 		return nil, err
 	}
 
-	if ip := net.ParseIP(serv.Host); ip != nil {
-		records = append(records, serv.NewPTR(q.Name, serv.Ttl))
-	}
+	records = append(records, serv.NewPTR(q.Name, serv.Ttl))
 	return records, nil
 }
 

--- a/server/server.go
+++ b/server/server.go
@@ -379,7 +379,7 @@ func (s *server) ServeDNS(w dns.ResponseWriter, req *dns.Msg) {
 		m.Answer = append(m.Answer, records...)
 		m.Extra = append(m.Extra, extra...)
 	case dns.TypeA, dns.TypeAAAA:
-		records, err := s.AddressRecords(q, name, nil, bufsize, dnssec)
+		records, err := s.AddressRecords(q, name, nil, bufsize, dnssec, false)
 		if err != nil {
 			if e, ok := err.(*etcd.EtcdError); ok {
 				if e.ErrorCode == 100 {
@@ -440,8 +440,7 @@ func (s *server) ServeDNS(w dns.ResponseWriter, req *dns.Msg) {
 	}
 }
 
-func (s *server) AddressRecords(q dns.Question, name string, previousRecords []dns.RR, bufsize uint16, dnssec bool) (records []dns.RR, err error) {
-	// if the q.Qtype is 0 we special case and return *all* records.
+func (s *server) AddressRecords(q dns.Question, name string, previousRecords []dns.RR, bufsize uint16, dnssec, both bool) (records []dns.RR, err error) {
 	services, err := s.backend.Records(name, false)
 	if err != nil {
 		return nil, err
@@ -468,7 +467,7 @@ func (s *server) AddressRecords(q dns.Question, name string, previousRecords []d
 			}
 
 			nextRecords, err := s.AddressRecords(dns.Question{Name: dns.Fqdn(serv.Host), Qtype: q.Qtype, Qclass: q.Qclass},
-				strings.ToLower(dns.Fqdn(serv.Host)), append(previousRecords, newRecord), bufsize, dnssec)
+				strings.ToLower(dns.Fqdn(serv.Host)), append(previousRecords, newRecord), bufsize, dnssec, both)
 			if err == nil {
 				// Only have we found something we should add the CNAME and the IP addresses.
 				if len(nextRecords) > 0 {
@@ -495,9 +494,9 @@ func (s *server) AddressRecords(q dns.Question, name string, previousRecords []d
 
 			log.Printf("skydns: incomplete CNAME chain for %s", name)
 
-		case ip.To4() != nil && (q.Qtype == dns.TypeA || q.Qtype == 0):
+		case ip.To4() != nil && (q.Qtype == dns.TypeA || both):
 			records = append(records, serv.NewA(q.Name, ip.To4()))
-		case ip.To4() == nil && (q.Qtype == dns.TypeAAAA || q.Qtype == 0):
+		case ip.To4() == nil && (q.Qtype == dns.TypeAAAA || both):
 			records = append(records, serv.NewAAAA(q.Name, ip.To16()))
 		}
 	}
@@ -568,33 +567,35 @@ func (s *server) SRVRecords(q dns.Question, name string, bufsize uint16, dnssec 
 			srv := serv.NewSRV(q.Name, weight)
 			records = append(records, srv)
 
-			if _, ok := lookup[srv.Target]; !ok {
-				lookup[srv.Target] = true
+			if _, ok := lookup[srv.Target]; ok {
+				break
+			}
 
-				if !dns.IsSubDomain(s.config.Domain, srv.Target) {
-					m1, e1 := s.Lookup(srv.Target, dns.TypeA, bufsize, dnssec)
-					if e1 == nil {
-						extra = append(extra, m1.Answer...)
-					}
-					m1, e1 = s.Lookup(srv.Target, dns.TypeAAAA, bufsize, dnssec)
-					if e1 == nil {
-						// If we have seen CNAME's we *assume* that they are already added.
-						for _, a := range m1.Answer {
-							if _, ok := a.(*dns.CNAME); !ok {
-								extra = append(extra, a)
-							}
+			lookup[srv.Target] = true
+
+			if !dns.IsSubDomain(s.config.Domain, srv.Target) {
+				m1, e1 := s.Lookup(srv.Target, dns.TypeA, bufsize, dnssec)
+				if e1 == nil {
+					extra = append(extra, m1.Answer...)
+				}
+				m1, e1 = s.Lookup(srv.Target, dns.TypeAAAA, bufsize, dnssec)
+				if e1 == nil {
+					// If we have seen CNAME's we *assume* that they are already added.
+					for _, a := range m1.Answer {
+						if _, ok := a.(*dns.CNAME); !ok {
+							extra = append(extra, a)
 						}
 					}
-					break
 				}
-				// Internal name, we should have some info on them, either v4 or v6
-				// Clients expect a complete answer, because we are a recursor in their
-				// view. q.Qtype is special here (0), so we get both v4 and v6.
-				addr, e1 := s.AddressRecords(dns.Question{srv.Target, dns.ClassINET, 0},
-					srv.Target, nil, bufsize, dnssec)
-				if e1 == nil {
-					extra = append(extra, addr...)
-				}
+				break
+			}
+			// Internal name, we should have some info on them, either v4 or v6
+			// Clients expect a complete answer, because we are a recursor in their
+			// view.
+			addr, e1 := s.AddressRecords(dns.Question{srv.Target, dns.ClassINET, dns.TypeA},
+				srv.Target, nil, bufsize, dnssec, true)
+			if e1 == nil {
+				extra = append(extra, addr...)
 			}
 		case ip.To4() != nil:
 			serv.Host = msg.Domain(serv.Key)

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -871,6 +871,14 @@ var dnsTestCases = []dnsTestCase{
 		Answer: []dns.RR{newA("upper.skydns.test. IN A 127.0.0.1")},
 	},
 
+	// SRV record with name that is internally resolvable.
+	{
+		Qname: "1.cname.skydns.test.", Qtype: dns.TypeSRV,
+		Answer: []dns.RR{newSRV("1.cname.skydns.test. IN SRV 10 100 0 104.server1.development.region1.skydns.test.")},
+		Extra:  []dns.RR{newA("104.server1.development.region1.skydns.test. IN A 10.0.0.1")},
+	},
+	// SRV record with name that is internally resolvable. Get v4 and v6 records.
+	{},
 }
 
 func newA(rr string) *dns.A           { r, _ := dns.NewRR(rr); return r.(*dns.A) }

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -529,7 +529,8 @@ var services = []*msg.Service{
 	{Host: "mx.skydns.test", Priority: 50, Mail: true, Key: "a.mail.skydns.test."},
 	{Host: "mx.miek.nl", Priority: 50, Mail: true, Key: "b.mail.skydns.test."},
 	{Host: "a.ipaddr.skydns.test", Priority: 30, Mail: true, Key: "a.mx.skydns.test."},
-	{Host: "b.ipaddr.skydns.test", Mail: true, Key: "b.mx.skydns.test."},
+	// If this is added, we get a double CNAME, see issue #168
+	// {Host: "b.ipaddr.skydns.test", Mail: true, Key: "b.mx.skydns.test."},
 }
 
 var dnsTestCases = []dnsTestCase{
@@ -958,20 +959,23 @@ var dnsTestCases = []dnsTestCase{
 	},
 
 	{
-		// Can't resolve to an IP - ignore
+		// See issue #168
 		Qname: "a.mail.skydns.test.", Qtype: dns.TypeMX,
 		Answer: []dns.RR{newMX("a.mail.skydns.test. IN MX 50 mx.skydns.test.")},
+		Extra: []dns.RR{
+			newA("a.ipaddr.skydns.test. IN A 172.16.1.1"),
+			newCNAME("mx.skydns.tests. IN CNAME a.ipaddr.skydns.test."),
+		},
 	},
 
 	{
 		Qname: "mx.skydns.test.", Qtype: dns.TypeMX,
 		Answer: []dns.RR{
-			newMX("mx.skydns.test. IN MX 10 b.ipaddr.skydns.test. "),
 			newMX("mx.skydns.test. IN MX 30 a.ipaddr.skydns.test. "),
 		},
 		Extra: []dns.RR{
 			// not working yet.
-			newA("bar.skydns.test. 3600 A 192.168.0.1"),
+			newA("a.ipaddr.skydns.test. A 172.16.1.1"),
 		},
 	},
 }

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -33,7 +33,7 @@ func addService(t *testing.T, s *server, k string, ttl uint64, m *msg.Service) {
 		t.Fatal(err)
 	}
 	path, _ := msg.PathWithWildcard(k)
-	t.Logf("Adding path %s:", path)
+
 	_, err = s.backend.(*backendetcd.Backend).Client().Create(path, string(b), ttl)
 	if err != nil {
 		// TODO(miek): allow for existing keys...
@@ -265,7 +265,6 @@ func TestDNS(t *testing.T) {
 			m.Question[0].Qclass = dns.ClassCHAOS
 		}
 		resp, _, err := c.Exchange(m, "127.0.0.1:"+StrPort)
-		t.Logf("question: %s\n", m.Question[0].String())
 		if err != nil {
 			// try twice, be more resilent against remote lookups
 			// timing out.
@@ -277,100 +276,131 @@ func TestDNS(t *testing.T) {
 		sort.Sort(rrSet(resp.Answer))
 		sort.Sort(rrSet(resp.Ns))
 		sort.Sort(rrSet(resp.Extra))
-		t.Logf("%s\n", resp)
+		fatal := false
+		defer func() {
+			if fatal {
+				t.Logf("question: %s\n", m.Question[0].String())
+				t.Logf("%s\n", resp)
+			}
+		}()
 		if resp.Rcode != tc.Rcode {
+			fatal = true
 			t.Fatalf("rcode is %q, expected %q", dns.RcodeToString[resp.Rcode], dns.RcodeToString[tc.Rcode])
 		}
 		if len(resp.Answer) != len(tc.Answer) {
+			fatal = true
 			t.Fatalf("answer for %q contained %d results, %d expected", tc.Qname, len(resp.Answer), len(tc.Answer))
 		}
 		for i, a := range resp.Answer {
 			if a.Header().Name != tc.Answer[i].Header().Name {
+				fatal = true
 				t.Fatalf("answer %d should have a Header Name of %q, but has %q", i, tc.Answer[i].Header().Name, a.Header().Name)
 			}
 			if a.Header().Ttl != tc.Answer[i].Header().Ttl {
+				fatal = true
 				t.Fatalf("Answer %d should have a Header TTL of %d, but has %d", i, tc.Answer[i].Header().Ttl, a.Header().Ttl)
 			}
 			if a.Header().Rrtype != tc.Answer[i].Header().Rrtype {
+				fatal = true
 				t.Fatalf("answer %d should have a header response type of %d, but has %d", i, tc.Answer[i].Header().Rrtype, a.Header().Rrtype)
 			}
 			switch x := a.(type) {
 			case *dns.SRV:
 				if x.Priority != tc.Answer[i].(*dns.SRV).Priority {
+					fatal = true
 					t.Fatalf("answer %d should have a Priority of %d, but has %d", i, tc.Answer[i].(*dns.SRV).Priority, x.Priority)
 				}
 				if x.Weight != tc.Answer[i].(*dns.SRV).Weight {
+					fatal = true
 					t.Fatalf("answer %d should have a Weight of %d, but has %d", i, tc.Answer[i].(*dns.SRV).Weight, x.Weight)
 				}
 				if x.Port != tc.Answer[i].(*dns.SRV).Port {
+					fatal = true
 					t.Fatalf("answer %d should have a Port of %d, but has %d", i, tc.Answer[i].(*dns.SRV).Port, x.Port)
 				}
 				if x.Target != tc.Answer[i].(*dns.SRV).Target {
+					fatal = true
 					t.Fatalf("answer %d should have a Target of %q, but has %q", i, tc.Answer[i].(*dns.SRV).Target, x.Target)
 				}
 			case *dns.A:
 				if x.A.String() != tc.Answer[i].(*dns.A).A.String() {
+					fatal = true
 					t.Fatalf("answer %d should have a Address of %q, but has %q", i, tc.Answer[i].(*dns.A).A.String(), x.A.String())
 				}
 			case *dns.AAAA:
 				if x.AAAA.String() != tc.Answer[i].(*dns.AAAA).AAAA.String() {
+					fatal = true
 					t.Fatalf("answer %d should have a Address of %q, but has %q", i, tc.Answer[i].(*dns.AAAA).AAAA.String(), x.AAAA.String())
 				}
 			case *dns.TXT:
 				for j, txt := range x.Txt {
 					if txt != tc.Answer[i].(*dns.TXT).Txt[j] {
+						fatal = true
 						t.Fatalf("answer %d should have a Txt of %q, but has %q", i, tc.Answer[i].(*dns.TXT).Txt[j], txt)
 					}
 				}
 			case *dns.DNSKEY:
 				tt := tc.Answer[i].(*dns.DNSKEY)
 				if x.Flags != tt.Flags {
+					fatal = true
 					t.Fatalf("DNSKEY flags should be %q, but is %q", x.Flags, tt.Flags)
 				}
 				if x.Protocol != tt.Protocol {
+					fatal = true
 					t.Fatalf("DNSKEY protocol should be %q, but is %q", x.Protocol, tt.Protocol)
 				}
 				if x.Algorithm != tt.Algorithm {
+					fatal = true
 					t.Fatalf("DNSKEY algorithm should be %q, but is %q", x.Algorithm, tt.Algorithm)
 				}
 			case *dns.RRSIG:
 				tt := tc.Answer[i].(*dns.RRSIG)
 				if x.TypeCovered != tt.TypeCovered {
+					fatal = true
 					t.Fatalf("RRSIG type-covered should be %d, but is %d", x.TypeCovered, tt.TypeCovered)
 				}
 				if x.Algorithm != tt.Algorithm {
+					fatal = true
 					t.Fatalf("RRSIG algorithm should be %d, but is %d", x.Algorithm, tt.Algorithm)
 				}
 				if x.Labels != tt.Labels {
+					fatal = true
 					t.Fatalf("RRSIG label should be %d, but is %d", x.Labels, tt.Labels)
 				}
 				if x.OrigTtl != tt.OrigTtl {
+					fatal = true
 					t.Fatalf("RRSIG orig-ttl should be %d, but is %d", x.OrigTtl, tt.OrigTtl)
 				}
 				if x.KeyTag != tt.KeyTag {
+					fatal = true
 					t.Fatalf("RRSIG key-tag should be %d, but is %d", x.KeyTag, tt.KeyTag)
 				}
 				if x.SignerName != tt.SignerName {
+					fatal = true
 					t.Fatalf("RRSIG signer-name should be %q, but is %q", x.SignerName, tt.SignerName)
 				}
 			case *dns.SOA:
 				tt := tc.Answer[i].(*dns.SOA)
 				if x.Ns != tt.Ns {
+					fatal = true
 					t.Fatalf("SOA nameserver should be %q, but is %q", x.Ns, tt.Ns)
 				}
 			case *dns.PTR:
 				tt := tc.Answer[i].(*dns.PTR)
 				if x.Ptr != tt.Ptr {
+					fatal = true
 					t.Fatalf("PTR ptr should be %q, but is %q", x.Ptr, tt.Ptr)
 				}
 			case *dns.CNAME:
 				tt := tc.Answer[i].(*dns.CNAME)
 				if x.Target != tt.Target {
+					fatal = true
 					t.Fatalf("CNAME target should be %q, but is %q", x.Target, tt.Target)
 				}
 			}
 		}
 		if len(resp.Ns) != len(tc.Ns) {
+			fatal = true
 			t.Fatalf("authority for %q contained %d results, %d expected", tc.Qname, len(resp.Ns), len(tc.Ns))
 		}
 		for i, n := range resp.Ns {
@@ -378,44 +408,53 @@ func TestDNS(t *testing.T) {
 			case *dns.SOA:
 				tt := tc.Ns[i].(*dns.SOA)
 				if x.Ns != tt.Ns {
+					fatal = true
 					t.Fatalf("SOA nameserver should be %q, but is %q", x.Ns, tt.Ns)
 				}
 			case *dns.NS:
 				tt := tc.Ns[i].(*dns.NS)
 				if x.Ns != tt.Ns {
+					fatal = true
 					t.Fatalf("NS nameserver should be %q, but is %q", x.Ns, tt.Ns)
 				}
 			case *dns.NSEC3:
 				tt := tc.Ns[i].(*dns.NSEC3)
 				if x.NextDomain != tt.NextDomain {
+					fatal = true
 					t.Fatalf("NSEC3 nextdomain should be %q, but is %q", x.NextDomain, tt.NextDomain)
 				}
 				if x.Hdr.Name != tt.Hdr.Name {
+					fatal = true
 					t.Fatalf("NSEC3 ownername should be %q, but is %q", x.Hdr.Name, tt.Hdr.Name)
 				}
 				for j, y := range x.TypeBitMap {
 					if y != tt.TypeBitMap[j] {
+						fatal = true
 						t.Fatalf("NSEC3 bitmap should have %q, but is %q", dns.TypeToString[y], dns.TypeToString[tt.TypeBitMap[j]])
 					}
 				}
 			}
 		}
 		if len(resp.Extra) != len(tc.Extra) {
+			fatal = true
 			t.Fatalf("additional for %q contained %d results, %d expected", tc.Qname, len(resp.Extra), len(tc.Extra))
 		}
 		for i, e := range resp.Extra {
 			switch x := e.(type) {
 			case *dns.A:
 				if x.A.String() != tc.Extra[i].(*dns.A).A.String() {
+					fatal = true
 					t.Fatalf("extra %d should have a address of %q, but has %q", i, tc.Extra[i].(*dns.A).A.String(), x.A.String())
 				}
 			case *dns.AAAA:
 				if x.AAAA.String() != tc.Extra[i].(*dns.AAAA).AAAA.String() {
+					fatal = true
 					t.Fatalf("extra %d should have a address of %q, but has %q", i, tc.Extra[i].(*dns.AAAA).AAAA.String(), x.AAAA.String())
 				}
 			case *dns.CNAME:
 				tt := tc.Extra[i].(*dns.CNAME)
 				if x.Target != tt.Target {
+					fatal = true
 					t.Fatalf("CNAME target should be %q, but is %q", x.Target, tt.Target)
 				}
 			}
@@ -458,6 +497,9 @@ var services = []*msg.Service{
 	{Host: "server2", Weight: 80, Key: "101.server2.region5.skydns.test."},
 	{Host: "server3", Weight: 150, Key: "103.server3.region5.skydns.test."},
 	{Host: "server4", Priority: 30, Key: "104.server4.region5.skydns.test."},
+	{Host: "172.16.1.1", Key: "a.ipaddr2.skydns.test."},
+	{Host: "2001::8:8:8:8", Key: "b.ipaddr2.skydns.test."},
+	{Host: "ipaddr2.skydns.test", Key: "both.v4v6.test.skydns.test."},
 
 	// A name: bar.skydns.test with 2 ports open and points to one ip: 192.168.0.1
 	{Host: "192.168.0.1", Port: 80, Key: "x.bar.skydns.test.", TargetStrip: 1},
@@ -878,7 +920,14 @@ var dnsTestCases = []dnsTestCase{
 		Extra:  []dns.RR{newA("104.server1.development.region1.skydns.test. IN A 10.0.0.1")},
 	},
 	// SRV record with name that is internally resolvable. Get v4 and v6 records.
-	{},
+	{
+		Qname: "both.v4v6.test.skydns.test.", Qtype: dns.TypeSRV,
+		Answer: []dns.RR{newSRV("both.v4v6.test.skydns.test. IN SRV 10 100 0 ipaddr2.skydns.test.")},
+		Extra:  []dns.RR{
+			newA("ipaddr2.skydns.test. IN A	172.16.1.1"),
+			newAAAA("ipaddr2.skydns.test. IN AAAA 2001::8:8:8:8"),
+		},
+	},
 }
 
 func newA(rr string) *dns.A           { r, _ := dns.NewRR(rr); return r.(*dns.A) }

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -472,6 +472,8 @@ var services = []*msg.Service{
 	// duplicate ip address
 	{Host: "10.11.11.10", Key: "http.multiport.http.skydns.test.", Port: 80},
 	{Host: "10.11.11.10", Key: "https.multiport.http.skydns.test.", Port: 443},
+	// uppercase name
+	{Host: "127.0.0.1", Key: "upper.skydns.test.", Port: 443},
 }
 
 var dnsTestCases = []dnsTestCase{
@@ -858,6 +860,17 @@ var dnsTestCases = []dnsTestCase{
 		Qname: "multiport.http.skydns.test.", Qtype: dns.TypeA,
 		Answer: []dns.RR{newA("multiport.http.skydns.test. IN A 10.11.11.10")},
 	},
+
+	// Casing test
+	{
+		Qname: "uppeR.skydns.test.", Qtype: dns.TypeA,
+		Answer: []dns.RR{newA("uppeR.skydns.test. IN A 127.0.0.1")},
+	},
+	{
+		Qname: "upper.skydns.test.", Qtype: dns.TypeA,
+		Answer: []dns.RR{newA("upper.skydns.test. IN A 127.0.0.1")},
+	},
+
 }
 
 func newA(rr string) *dns.A           { r, _ := dns.NewRR(rr); return r.(*dns.A) }


### PR DESCRIPTION
Add support for MX records, by extending `msg.Service`, with a `Mail` boolean field. Add 2-line explanation to the README.