### PR TITLE
Base docker image out of Alpine Linux

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
-FROM progrium/busybox
+FROM alpine:3.1
 MAINTAINER Miek Gieben <miek@miek.nl> (@miekg)
 
-RUN opkg-install bind-dig
+RUN apk --update add bind-tools && rm -rf /var/cache/apk/*
 
 ADD skydns skydns
 

--- a/README.md
+++ b/README.md
@@ -699,8 +699,15 @@ Official Docker images are at the [Docker Hub](https://registry.hub.docker.com/u
 * master -> skynetservices/skydns:latest
 * latest tag -> skynetservices/skydns:latest-tagged
 
-The supplied `Dockerfile` can be used to build an image as well. Build SkyDNS and then
-build the docker image:
+The supplied `Dockerfile` can be used to build an image as well. Note that the image
+is based of Alpine Linux which used musl libc instead of glibc, so when building
+SkyDNS you must make sure if does not need glibc when run:
+
+Build SkyDNS with:
+
+    % go build -ldflags "-linkmode external -extldflags -static"
+
+And then build the docker image:
 
     % go build
     % docker build -t $USER/skydns .


### PR DESCRIPTION
progium/busybox will soon be deprecated and they point to Alpine
Linux. Make the changes to our repo and document how to build
SkyDNS because Alpine Linux used musl libc instead of glibc.