### PR TITLE
Create minimized Docker images with static GO binaries

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,3 +1,3 @@
 skydns
 skydns_*
-tags
+.git

--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -5,3 +5,4 @@ Brian Ketelsen <bketelsen@gmail.com>
 Miek Gieben <miek@miek.nl>
 Sean Carey <sean@densone.com>
 Michael Crosby <michael@crosbymichael.com>
+Dieter Reuter <dieter.reuter@me.com>

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,12 @@
-FROM progrium/busybox
-MAINTAINER Miek Gieben <miek@miek.nl> (@miekg)
+FROM golang:1.4-cross
 
-RUN opkg-install bind-dig
+RUN go get \
+    github.com/coreos/etcd \
+    github.com/coreos/go-etcd/etcd \
+    github.com/coreos/go-systemd/activation \
+    github.com/miekg/dns \
+    github.com/rcrowley/go-metrics \
+    github.com/rcrowley/go-metrics/stathat
 
-ADD skydns skydns
-
-EXPOSE 53 53/udp
-ENTRYPOINT ["/skydns"]
+WORKDIR /go/src/github.com/skynetservices/skydns
+ADD . /go/src/github.com/skynetservices/skydns

--- a/README.md
+++ b/README.md
@@ -699,11 +699,22 @@ Official Docker images are at the [Docker Hub](https://registry.hub.docker.com/u
 * master -> skynetservices/skydns:latest
 * latest tag -> skynetservices/skydns:latest-tagged
 
-The supplied `Dockerfile` can be used to build an image as well. Build SkyDNS and then
-build the docker image:
+Building the SkyDNS Docker images will be done using GO cross compiling to static
+GO binaries. To build the Docker images just use the supplied build script:
 
-    % go build
-    % docker build -t $USER/skydns .
+    % ./docker-builder/build.sh
+
+As a first step, a complete Docker builder image will be created. For subsequent
+builds you can skip this step with:
+
+    % SKIP_BUILD=1 ./docker-builder/build.sh
+
+The created Docker images are extremely small in size due to the fact that we just
+use a statically compiled GO binary inside the Docker image:
+
+    % docker images | grep skydns
+    skydns-armv6l       latest              fd08790bc973        Less than a second ago   6.806 MB
+    skydns              latest              4da909d03f4a        2 seconds ago            8.437 MB
 
 If you run it, SkyDNS needs to access Etcd (or whatever backend), which usually
 runs on the host server (i.e. when using CoreOS), to make that work, just run:

--- a/docker-builder/build.sh
+++ b/docker-builder/build.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+set -e
+
+# Get rid of existing binaries
+echo "Remove old binaries..."
+rm -f ./docker-builder/dockerimage-skydns*/skydns_*
+
+# Build Docker image unless we opt out of it
+if [[ -z "$SKIP_BUILD" ]]; then
+	echo "Build the builder docker image..."
+    docker build -t skydns-builder .
+fi
+
+# Let's crosscompile and produce static GO binaries
+echo "Crosscompile..."
+docker run --rm -v `pwd`:/go/src/github.com/skynetservices/skydns skydns-builder bash -c 'GOOS=linux GOARCH=amd64 CGO_ENABLED=0 go build -a -installsuffix nocgo -o docker-builder/dockerimage-skydns/skydns_linux-amd64'
+docker run --rm -v `pwd`:/go/src/github.com/skynetservices/skydns skydns-builder bash -c 'GOOS=linux GOARCH=arm CGO_ENABLED=0 go build -a -installsuffix nocgo -o docker-builder/dockerimage-skydns-armv6l/skydns_linux-arm'
+ls -al docker-builder/dockerimage-skydns*/skydns_linux-*
+
+# Now build minimized Docker images
+echo "Build Docker Images..."
+docker build -t skydns ./docker-builder/dockerimage-skydns/
+docker build -t skydns-armv6l ./docker-builder/dockerimage-skydns-armv6l/
+docker images | grep skydns

--- a/docker-builder/dockerimage-skydns-armv6l/Dockerfile
+++ b/docker-builder/dockerimage-skydns-armv6l/Dockerfile
@@ -1,0 +1,7 @@
+FROM scratch
+MAINTAINER Miek Gieben <miek@miek.nl> (@miekg)
+
+ADD skydns_linux-arm /skydns
+
+EXPOSE 53 53/udp
+ENTRYPOINT ["/skydns"]

--- a/docker-builder/dockerimage-skydns/Dockerfile
+++ b/docker-builder/dockerimage-skydns/Dockerfile
@@ -1,0 +1,7 @@
+FROM scratch
+MAINTAINER Miek Gieben <miek@miek.nl> (@miekg)
+
+ADD skydns_linux-amd64 /skydns
+
+EXPOSE 53 53/udp
+ENTRYPOINT ["/skydns"]


### PR DESCRIPTION
with the provided build script `./docker-builder/build.sh` SkyDNS will be compiled to a statically linked GO binary which has absolute no other runtime dependencies. Now it's possible to create a minimal Docker image without any OS base layer required.

```
skydns          for Intel x86-64
skydns-armv6l   for ARMv6 system like Raspberry Pi 1/2, and other ARMv7 as well
```

Signed-off-by: Dieter Reuter <dieter.reuter@me.com>