### PR TITLE
WIP - Allow config to set listen on ipv4 only

### DIFF
--- a/server/config.go
+++ b/server/config.go
@@ -23,6 +23,11 @@ const (
 type Config struct {
 	// The ip:port SkyDNS should be listening on for incoming DNS requests.
 	DnsAddr string `json:"dns_addr,omitempty"`
+	// The network used for DNS - can be 'tcp', 'tcp4', or 'tcp6', defaults to 'tcp'
+	TcpNetwork string `json:"tcp_network,omitempty"`
+	// UdpNetwork may be set to 'udp', 'udp4', or 'udp6', defaults to the equivalent
+	// from TcpNetwork
+	UdpNetwork string `json:"-"`
 	// bind to port(s) activated by systemd. If set to true, this overrides DnsAddr.
 	Systemd bool `json:"systemd,omitempty"`
 	// The domain SkyDNS is authoritative for, defaults to skydns.local.
@@ -78,6 +83,9 @@ func SetDefaults(config *Config) error {
 	if config.DnsAddr == "" {
 		config.DnsAddr = "127.0.0.1:53"
 	}
+	if config.TcpNetwork == "" {
+		config.TcpNetwork = "tcp"
+	}
 	if config.Domain == "" {
 		config.Domain = "skydns.local."
 	}
@@ -107,6 +115,22 @@ func SetDefaults(config *Config) error {
 	}
 	if config.Ndots <= 0 {
 		config.Ndots = 2
+	}
+
+	switch config.TcpNetwork {
+	case "tcp", "tcp4", "tcp6":
+	default:
+		return fmt.Errorf("%s is not an accepted value for TCPNetwork", config.TcpNetwork)
+	}
+	if config.UdpNetwork == "" {
+		switch config.TcpNetwork {
+		case "tcp":
+			config.UdpNetwork = "udp"
+		case "tcp4":
+			config.UdpNetwork = "udp4"
+		case "tcp6":
+			config.UdpNetwork = "udp6"
+		}
 	}
 
 	if len(config.Nameservers) == 0 {


### PR DESCRIPTION
Golang automatically listens on both ipv4 and ipv6 interfaces
when "tcp" or "udp" is used. However, clients that connect via
an ipv6 route to a system that is only available on ipv4 may
get no responses for A records. This config option lets a caller
specify tcp (current behavior), tcp4 (ipv4 only), and tcp6 (ipv6
only). UDP inherits the equivalent default.

Listening only on ipv4 when a system also has an ipv6 address bound
resolved issues with DNS clients getting no A records (only AAAA).
Listening only on ipv4 for 0.0.0.0 doesn't seem unreasonable.

Open to other factorings - I didn't want to do a tri state flag
on "both", "ipv4", and "ipv6" because that has to be converted
to UDP as well.