### PR TITLE
let skyDNS support local domain query forwarding

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,7 @@ SkyDNS' configuration is stored in etcd as a JSON object under the key
 * `nameservers`: forward DNS requests to these (recursive) nameservers (array of IP:port combination),
     when not authoritative for a domain. This defaults to the servers listed in `/etc/resolv.conf`. Also
     see `no_rec`.
+* `forward-local`: forward local queries to nameservers. Default is false.
 * `no_rec`: never (ever) provide a recursive service (i.e. forward to the servers provided in -nameservers).
 * `read_timeout`: network read timeout, for DNS and talking with etcd.
 * `ttl`: default TTL in seconds to use on replies when none is set in etcd, defaults to 3600.

--- a/main.go
+++ b/main.go
@@ -48,6 +48,7 @@ func init() {
 	flag.StringVar(&config.Domain, "domain", env("SKYDNS_DOMAIN", "skydns.local."), "domain to anchor requests to (SKYDNS_DOMAIN)")
 	flag.StringVar(&config.DnsAddr, "addr", env("SKYDNS_ADDR", "127.0.0.1:53"), "ip:port to bind to (SKYDNS_ADDR)")
 	flag.StringVar(&nameserver, "nameservers", env("SKYDNS_NAMESERVERS", ""), "nameserver address(es) to forward (non-local) queries to e.g. 8.8.8.8:53,8.8.4.4:53")
+	flag.BoolVar(&config.ForwardLocal, "forward-local", false, "do not forward local queries e.g. *.skydns.local query will not forward to nameservers")
 	flag.BoolVar(&config.NoRec, "no-rec", false, "do not provide a recursive service")
 	flag.StringVar(&machine, "machines", env("ETCD_MACHINES", ""), "machine address(es) running etcd")
 	flag.StringVar(&config.DNSSEC, "dnssec", "", "basename of DNSSEC key file e.q. Kskydns.local.+005+38250")

--- a/server/config.go
+++ b/server/config.go
@@ -38,6 +38,8 @@ type Config struct {
 	RoundRobin bool `json:"round_robin,omitempty"`
 	// List of ip:port, seperated by commas of recursive nameservers to forward queries to.
 	Nameservers []string `json:"nameservers,omitempty"`
+	// Forward local queries to nameservers. Default is false.
+	ForwardLocal bool `json:"forward_local,omitempty"`
 	// Never provide a recursive service.
 	NoRec       bool          `json:"no_rec,omitempty"`
 	ReadTimeout time.Duration `json:"read_timeout,omitempty"`


### PR DESCRIPTION
I have two skyDNS instance, if the first one do not return, i want forward the same query to the second skyDNS instance.

Do you need it?