### PR TITLE
If host has no /etc/resolv.conf, don't error out

### DIFF
--- a/server/config.go
+++ b/server/config.go
@@ -8,6 +8,7 @@ import (
 	"crypto"
 	"fmt"
 	"net"
+	"os"
 	"strings"
 	"time"
 
@@ -112,11 +113,13 @@ func SetDefaults(config *Config) error {
 
 	if len(config.Nameservers) == 0 {
 		c, err := dns.ClientConfigFromFile("/etc/resolv.conf")
-		if err != nil {
-			return err
-		}
-		for _, s := range c.Servers {
-			config.Nameservers = append(config.Nameservers, net.JoinHostPort(s, c.Port))
+		if !os.IsNotExist(err) {
+			if err != nil {
+				return err
+			}
+			for _, s := range c.Servers {
+				config.Nameservers = append(config.Nameservers, net.JoinHostPort(s, c.Port))
+			}
 		}
 	}
 	config.Domain = dns.Fqdn(strings.ToLower(config.Domain))


### PR DESCRIPTION
It should be possible to run SkyDNS with no nameservers on a host that
has no /etc/resolv.conf

Hit this when running skydns in Docker and empty DNS settings were passed.