### PR TITLE
Env config support for systemd socket activation

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,6 +126,7 @@ SkyDNS uses these environment variables:
 * `SKYDNS_NAMESERVERS` - set a list of nameservers to forward DNS requests to
   when not authoritative for a domain, "8.8.8.8:53,8.8.4.4:53".
 * `SKYDNS_PATH_PREFIX` - backend(etcd) path prefix, defaults to skydns (i.e. if it is set to `mydns`, the SkyDNS's configuration object should be stored under the key `/mydns/config`).
+* `SKYDNS_SYSTEMD`: set to `true` to bind to socket(s) activated by systemd (ignores SKYDNS_ADDR).
 
 And these are used for statistics:
 

--- a/main.go
+++ b/main.go
@@ -44,6 +44,15 @@ func env(key, def string) string {
 	return def
 }
 
+func boolEnv(key string, def bool) bool {
+	if x := os.Getenv(key); x != "" {
+		if v, err := strconv.ParseBool(x); err == nil {
+			return v
+		}
+	}
+	return def
+}
+
 func init() {
 	flag.StringVar(&config.Domain, "domain", env("SKYDNS_DOMAIN", "skydns.local."), "domain to anchor requests to (SKYDNS_DOMAIN)")
 	flag.StringVar(&config.DnsAddr, "addr", env("SKYDNS_ADDR", "127.0.0.1:53"), "ip:port to bind to (SKYDNS_ADDR)")
@@ -60,7 +69,7 @@ func init() {
 	flag.BoolVar(&discover, "discover", false, "discover new machines by watching /v2/_etcd/machines")
 	flag.BoolVar(&stub, "stubzones", false, "support stub zones")
 	flag.BoolVar(&config.Verbose, "verbose", false, "log queries")
-	flag.BoolVar(&config.Systemd, "systemd", false, "bind to socket(s) activated by systemd (ignore -addr)")
+	flag.BoolVar(&config.Systemd, "systemd", boolEnv("SKYDNS_SYSTEMD", false), "bind to socket(s) activated by systemd (ignore -addr)")
 
 	// TTl
 	// Minttl


### PR DESCRIPTION
This comes in handy when it's easy to modify environment variables, but it's difficult to modify the actual command line used to start skydns.

I'm running into this situation with Fedora's skydns package, but it seems like systemd encourages this style, so I assume this change would make other people's lives easier as well.

Thank you very much for skydns! It's making my life so much easier!