### PR TITLE
Set min to mid to fix binary search in Fit()

### DIFF
--- a/server/msg.go
+++ b/server/msg.go
@@ -40,7 +40,7 @@ func Fit(m *dns.Msg, size int, tcp bool) (*dns.Msg, bool) {
 		m.Answer = original[:mid]
 
 		if m.Len() < size {
-			min++
+			min = mid + 1
 			continue
 		}
 		max = mid


### PR DESCRIPTION
Hi,

if I understand this algorithm correctly, the lower bound should be set to `mid` if the target size is smaller than the intended size.