### PR TITLE
Dockerfile: use latest alpine image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.1
+FROM alpine:latest
 MAINTAINER Miek Gieben <miek@miek.nl> (@miekg)
 
 RUN apk --update add bind-tools && rm -rf /var/cache/apk/*


### PR DESCRIPTION
This PR changes the Dockerfile to use the latest available alpine image, not the older 3.1 image.