### PR TITLE
exact match flag with round-robin support

### DIFF
--- a/main.go
+++ b/main.go
@@ -70,6 +70,7 @@ func init() {
 	flag.StringVar(&cacert, "ca-cert", env("ETCD_CACERT", ""), "CA Certificate")
 	flag.DurationVar(&config.ReadTimeout, "rtimeout", 2*time.Second, "read timeout")
 	flag.BoolVar(&config.RoundRobin, "round-robin", true, "round robin A/AAAA replies")
+	flag.BoolVar(&config.ExactMatch, "exact", false, "only exact matches (except round robin x[0-9] subkeys)")
 	flag.BoolVar(&config.NSRotate, "ns-rotate", true, "round robin selection of nameservers from among those listed")
 	flag.BoolVar(&stub, "stubzones", false, "support stub zones")
 	flag.BoolVar(&config.Verbose, "verbose", false, "log queries")

--- a/server/config.go
+++ b/server/config.go
@@ -37,6 +37,8 @@ type Config struct {
 	DNSSEC     string `json:"dnssec,omitempty"`
 	// Round robin A/AAAA replies. Default is true.
 	RoundRobin bool `json:"round_robin,omitempty"`
+	// Exact match keys exept x[0-9] subkeys for round robin
+	ExactMatch bool `json:"exact_match,omitempty"`
 	// Round robin selection of nameservers from among those listed, rather than have all forwarded requests try the first listed server first every time.
 	NSRotate bool `json:"ns_rotate,omitempty"`
 	// List of ip:port, seperated by commas of recursive nameservers to forward queries to.

--- a/server/server.go
+++ b/server/server.go
@@ -418,7 +418,7 @@ func (s *server) ServeDNS(w dns.ResponseWriter, req *dns.Msg) {
 }
 
 func (s *server) AddressRecords(q dns.Question, name string, previousRecords []dns.RR, bufsize uint16, dnssec, both bool) (records []dns.RR, err error) {
-	services, err := s.backend.Records(name, false)
+	services, err := s.backend.Records(name, s.config.ExactMatch)
 	if err != nil {
 		return nil, err
 	}
@@ -483,7 +483,7 @@ func (s *server) AddressRecords(q dns.Question, name string, previousRecords []d
 
 // NSRecords returns NS records from etcd.
 func (s *server) NSRecords(q dns.Question, name string) (records []dns.RR, extra []dns.RR, err error) {
-	services, err := s.backend.Records(name, false)
+	services, err := s.backend.Records(name, s.config.ExactMatch)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -511,7 +511,7 @@ func (s *server) NSRecords(q dns.Question, name string) (records []dns.RR, extra
 // SRVRecords returns SRV records from etcd.
 // If the Target is not a name but an IP address, a name is created.
 func (s *server) SRVRecords(q dns.Question, name string, bufsize uint16, dnssec bool) (records []dns.RR, extra []dns.RR, err error) {
-	services, err := s.backend.Records(name, false)
+	services, err := s.backend.Records(name, s.config.ExactMatch)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -596,7 +596,7 @@ func (s *server) SRVRecords(q dns.Question, name string, bufsize uint16, dnssec 
 // MXRecords returns MX records from etcd.
 // If the Target is not a name but an IP address, a name is created.
 func (s *server) MXRecords(q dns.Question, name string, bufsize uint16, dnssec bool) (records []dns.RR, extra []dns.RR, err error) {
-	services, err := s.backend.Records(name, false)
+	services, err := s.backend.Records(name, s.config.ExactMatch)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -670,7 +670,7 @@ func (s *server) CNAMERecords(q dns.Question, name string) (records []dns.RR, er
 }
 
 func (s *server) TXTRecords(q dns.Question, name string) (records []dns.RR, err error) {
-	services, err := s.backend.Records(name, false)
+	services, err := s.backend.Records(name, s.config.ExactMatch)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Allows to return only exact matches but with round-robin 'x[0-9]' subkeys if presented.

We need to prevent any recursive searches down the subtree for security reasons, so there is "exact" flag added.
But we still need the round-robin functionality for some services, so there is a tweak for this that allows loop through direct children with 'x[0-9]' keys.