### PR TITLE
Run tests with Go 1.5 and 1.6 on TravisCI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,8 @@
 language: go
 
 go:
-  - 1.4
+  - 1.5
+  - 1.6
 
 install:
   - go get github.com/coreos/etcd


### PR DESCRIPTION
Hi,

i updated the .travis.yaml that th etests will run now on Go 1.5 and Go 1.6

Best wishes,
Matthias