### PR TITLE
Falling back to the default config doesn't make sense

### DIFF
--- a/main.go
+++ b/main.go
@@ -175,8 +175,7 @@ func loadConfig(client etcd.KeysAPI, config *server.Config) error {
 	configPath := "/" + msg.PathPrefix + "/config"
 	resp, err := client.Get(ctx, configPath, nil)
 	if err != nil {
-		log.Printf("skydns: falling back to default configuration, could not read from etcd: %s", err)
-		return nil
+		return fmt.Errorf("could not read from etcd: %s", err)
 	}
 	if err := json.Unmarshal([]byte(resp.Node.Value), config); err != nil {
 		return fmt.Errorf("failed to unmarshal config: %s", err.Error())


### PR DESCRIPTION
Fixes #276.

It's better to panic and pass the control to the process manager (systemd, docker, ...) than to continue with an unexpected configuration.

(.travis stuff are dropped, as discussed in #277)
