### PR TITLE
support SKYDNS_DOMAIN resolve itself

### DIFF
--- a/server/server.go
+++ b/server/server.go
@@ -358,6 +358,9 @@ func (s *server) ServeDNS(w dns.ResponseWriter, req *dns.Msg) {
 		m.Answer = append(m.Answer, records...)
 		m.Extra = append(m.Extra, extra...)
 	case dns.TypeA, dns.TypeAAAA:
+		if name == s.config.Domain {
+			name = string("self.") + name
+		}
 		records, err := s.AddressRecords(q, name, nil, bufsize, dnssec, false)
 		if isEtcdNameError(err, s) {
 			m = s.NameError(req)


### PR DESCRIPTION
dig example.com will linked to self.example.com
After I set SKYDNS_DOMAIN=example.com, reslove example.com returned all second-level domain typeA record, so I want to defind an alias named 'self', to get correct results.
Or we can defind an other string.