### PR TITLE
add support for etcd basic auth

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,6 +121,8 @@ SkyDNS uses these environment variables:
 * `ETCD_TLSKEY` - path of TLS client certificate - private key. Overwrite with `-tls-key` string flag.
 * `ETCD_TLSPEM` - path of TLS client certificate - public key. Overwrite with `-tls-pem` string flag.
 * `ETCD_CACERT` - path of TLS certificate authority public key. Overwrite with `-ca-cert` string flag.
+* `ETCD_USERNAME` - username used for basic auth. Overwrite with `-username` string flag.
+* `ETCD_PASSWORD` - password used for basic auth. Overwrite with `-password` string flag.
 * `SKYDNS_ADDR` - specify address to bind to. Overwrite with `-addr` string flag.
 * `SKYDNS_DOMAIN` - set a default domain if not specified by etcd config. Overwrite with `-domain` string flag.
 * `SKYDNS_NAMESERVERS` - set a list of nameservers to forward DNS requests to

--- a/main.go
+++ b/main.go
@@ -5,12 +5,9 @@
 package main
 
 import (
-	"crypto/tls"
-	"crypto/x509"
 	"encoding/json"
 	"flag"
 	"fmt"
-	"io/ioutil"
 	"log"
 	"math/rand"
 	"net"
@@ -26,6 +23,7 @@ import (
 	"github.com/skynetservices/skydns/server"
 
 	etcd "github.com/coreos/etcd/client"
+	"github.com/coreos/etcd/pkg/transport"
 	"github.com/miekg/dns"
 	"golang.org/x/net/context"
 )
@@ -65,9 +63,9 @@ func init() {
 	flag.StringVar(&machine, "machines", env("ETCD_MACHINES", "http://127.0.0.1:2379"), "machine address(es) running etcd")
 	flag.StringVar(&config.DNSSEC, "dnssec", "", "basename of DNSSEC key file e.q. Kskydns.local.+005+38250")
 	flag.StringVar(&config.Local, "local", "", "optional unique value for this skydns instance")
-	flag.StringVar(&tlskey, "tls-key", env("ETCD_TLSKEY", ""), "TLS Private Key path")
-	flag.StringVar(&tlspem, "tls-pem", env("ETCD_TLSPEM", ""), "X509 Certificate")
-	flag.StringVar(&cacert, "ca-cert", env("ETCD_CACERT", ""), "CA Certificate")
+	flag.StringVar(&tlskey, "tls-key", env("ETCD_TLSKEY", ""), "SSL key file used to secure etcd communication")
+	flag.StringVar(&tlspem, "tls-pem", env("ETCD_TLSPEM", ""), "SSL certification file used to secure etcd communication")
+	flag.StringVar(&cacert, "ca-cert", env("ETCD_CACERT", ""), "SSL Certificate Authority file used to secure etcd communication")
 	flag.DurationVar(&config.ReadTimeout, "rtimeout", 2*time.Second, "read timeout")
 	flag.BoolVar(&config.RoundRobin, "round-robin", true, "round robin A/AAAA replies")
 	flag.BoolVar(&config.NSRotate, "ns-rotate", true, "round robin selection of nameservers from among those listed")
@@ -199,37 +197,31 @@ func validateHostPort(hostPort string) error {
 	return nil
 }
 
-func newEtcdClient(machines []string, tlsCert, tlsKey, tlsCACert string) (etcd.KeysAPI, error) {
-	etcdCfg := etcd.Config{
-		Endpoints: machines,
-		Transport: newHTTPSTransport(tlsCert, tlsKey, tlsCACert),
+func newEtcdClient(machines []string, certFile, keyFile, caFile string) (etcd.KeysAPI, error) {
+	t, err := newHTTPSTransport(certFile, keyFile, caFile)
+	if err != nil {
+		return nil, err
 	}
-	cli, err := etcd.New(etcdCfg)
+
+	cli, err := etcd.New(etcd.Config{
+		Endpoints: machines,
+		Transport: t,
+	})
 	if err != nil {
 		return nil, err
 	}
 	return etcd.NewKeysAPI(cli), nil
 }
 
-func newHTTPSTransport(tlsCertFile, tlsKeyFile, tlsCACertFile string) etcd.CancelableTransport {
-	var cc *tls.Config = nil
-
-	if tlsCertFile != "" && tlsKeyFile != "" {
-		var rpool *x509.CertPool
-		if tlsCACertFile != "" {
-			if pemBytes, err := ioutil.ReadFile(tlsCACertFile); err == nil {
-				rpool = x509.NewCertPool()
-				rpool.AppendCertsFromPEM(pemBytes)
-			}
-		}
-
-		if tlsCert, err := tls.LoadX509KeyPair(tlsCertFile, tlsKeyFile); err == nil {
-			cc = &tls.Config{
-				RootCAs:            rpool,
-				Certificates:       []tls.Certificate{tlsCert},
-				InsecureSkipVerify: true,
-			}
-		}
+func newHTTPSTransport(certFile, keyFile, caFile string) (*http.Transport, error) {
+	info := transport.TLSInfo{
+		CertFile: certFile,
+		KeyFile:  keyFile,
+		CAFile:   caFile,
+	}
+	cfg, err := info.ClientConfig()
+	if err != nil {
+		return nil, err
 	}
 
 	tr := &http.Transport{
@@ -239,8 +231,8 @@ func newHTTPSTransport(tlsCertFile, tlsKeyFile, tlsCACertFile string) etcd.Cance
 			KeepAlive: 30 * time.Second,
 		}).Dial,
 		TLSHandshakeTimeout: 10 * time.Second,
-		TLSClientConfig:     cc,
+		TLSClientConfig:     cfg,
 	}
 
-	return tr
+	return tr, nil
 }


### PR DESCRIPTION
Fix #228. I think skydns has already support etcd auth, what we want is support etcd basic auth(username&password), am I right? If so I will open a new PR to implement this, this PR rewrite etcd client construction logical. 