### PR TITLE
Feature: support record view

### DIFF
--- a/msg/service.go
+++ b/msg/service.go
@@ -46,6 +46,9 @@ type Service struct {
 
 	// Etcd key where we found this service and ignored from json un-/marshalling
 	Key string `json:"-"`
+
+	Mask string
+	View string
 }
 
 // NewSRV returns a new SRV record based on the Service.


### PR DESCRIPTION
This feature likes view in Bind:
IP from 192.168.0.1 asks skydns for question "test.skydns.local" will get answer "1.1.1.1"
IP from 192.168.1.1 asks skydns for question "test.skydns.local" will get answer "2.2.2.2"

A or CNAME record in ETCD should have a little bit change:
Change from
curl -XPUT http://etcdip:2379/v2/keys/skydns/local/skydns/test/01 -d value='{"Host": "1.1.1.1", "Ttl": 60}'
curl -XPUT http://etcdip:2379/v2/keys/skydns/local/skydns/test/02 -d value='{"Host": "2.2.2.2", "Ttl": 60}'
To
curl -XPUT http://etcdip:2379/v2/keys/skydns/local/skydns/test/01 -d value='{"Host": "1.1.1.1", "Ttl": 60, "View": "192.168.0.0", "Mask": "255.255.255.0"}'
curl -XPUT http://etcdip:2379/v2/keys/skydns/local/skydns/test/02 -d value='{"Host": "2.2.2.2", "Ttl": 60, "View": "192.168.1.0", "Mask": "255.255.255.0"}'