### PR TITLE
increment request count for auth system

### DIFF
--- a/server/server.go
+++ b/server/server.go
@@ -248,6 +248,7 @@ func (s *server) ServeDNS(w dns.ResponseWriter, req *dns.Msg) {
 	metrics.ReportCacheMiss(metrics.Response)
 
 	defer func() {
+		metrics.ReportRequestCount(req, metrics.Auth)
 		metrics.ReportDuration(m, start, metrics.Auth)
 		metrics.ReportErrorCount(m, metrics.Auth)
 


### PR DESCRIPTION
First off, thank's for including prometheus metrics in your service and making it easy to expose for scraping because of that it was easy to get some stats!

However as I try to build some dashboards and alerting on the metrics I'm having a hard time with the results.

As an example I would expect `dns_request_count` to be a total count of every DNS request the server has received, regardless of how the request was handled. Instead it seems the metric is only incremented in a few different cases but the primary case of serving a DNS request such as `A` for a domain its auth for is not one of them.

This should get those requests included in the counter.