### PR TITLE
Etcd version 3 support for skydns

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ SkyDNS' configuration is stored in etcd as a JSON object under the key
 * `ndots`: how many labels a name should have before we allow forwarding. Default to 2.
 * `systemd`: bind to socket(s) activated by systemd (ignores -addr).
 * `path-prefix`: backend(etcd) path prefix, defaults to skydns (i.e. if it is set to `mydns`, the SkyDNS's configuration object should be stored under the key `/mydns/config`).
-* `etcd-version`: etcd version to be supported by skydns during runtime. Supported versions are etcd version 2 or etcd version 3. Support defaults to 2 (etcd version 2).
+* `etcd3`: flag that toggles the etcd version 3 support by skydns during runtime. Defaults to false.
 
 To set the configuration, use something like:
 

--- a/README.md
+++ b/README.md
@@ -82,6 +82,7 @@ SkyDNS' configuration is stored in etcd as a JSON object under the key
 * `ndots`: how many labels a name should have before we allow forwarding. Default to 2.
 * `systemd`: bind to socket(s) activated by systemd (ignores -addr).
 * `path-prefix`: backend(etcd) path prefix, defaults to skydns (i.e. if it is set to `mydns`, the SkyDNS's configuration object should be stored under the key `/mydns/config`).
+* `etcd-version`: etcd version to be supported by skydns during runtime. Supported versions are etcd version 2 or etcd version 3. Support defaults to 2 (etcd version 2).
 
 To set the configuration, use something like:
 

--- a/backends/etcd/etcd.go
+++ b/backends/etcd/etcd.go
@@ -15,9 +15,7 @@ import (
 	"github.com/skynetservices/skydns/singleflight"
 
 	etcd "github.com/coreos/etcd/client"
-	etcdv3 "github.com/coreos/etcd/clientv3"
 	"golang.org/x/net/context"
-	"github.com/coreos/etcd/mvcc/mvccpb"
 )
 
 // Config represents configuration for the Etcd backend - these values
@@ -34,26 +32,9 @@ type Backend struct {
 	inflight *singleflight.Group
 }
 
-type Backendv3 struct {
-	client   etcdv3.Client
-	ctx      context.Context
-	config   *Config
-	inflight *singleflight.Group
-}
-
 // NewBackend returns a new Backend for SkyDNS, backed by etcd.
 func NewBackend(client etcd.KeysAPI, ctx context.Context, config *Config) *Backend {
 	return &Backend{
-		client:   client,
-		ctx:      ctx,
-		config:   config,
-		inflight: &singleflight.Group{},
-	}
-}
-
-// NewBackendv3 returns a new Backend for SkyDNS, backed by etcd v3
-func NewBackendv3(client etcdv3.Client, ctx context.Context, config *Config) *Backendv3 {
-	return &Backendv3{
 		client:   client,
 		ctx:      ctx,
 		config:   config,
@@ -76,17 +57,6 @@ func (g *Backend) Records(name string, exact bool) ([]msg.Service, error) {
 	default:
 		return g.loopNodes([]*etcd.Node{r.Node}, segments, false, nil)
 	}
-}
-
-func (g *Backendv3) Records(name string, exact bool) ([]msg.Service, error) {
-	path, star := msg.PathWithWildcard(name)
-	r, err := g.get(path, true)
-	if err != nil {
-		return nil, err
-	}
-	segments := strings.Split(msg.Path(name), "/")
-
-	return g.loopNodes(r.Kvs, segments, star, nil)
 }
 
 func (g *Backend) ReverseRecord(name string) (*msg.Service, error) {
@@ -112,26 +82,6 @@ func (g *Backend) ReverseRecord(name string) (*msg.Service, error) {
 	return &records[0], nil
 }
 
-func (g *Backendv3) ReverseRecord(name string) (*msg.Service, error) {
-	path, star := msg.PathWithWildcard(name)
-	if star {
-		return nil, fmt.Errorf("reverse can not contain wildcards")
-	}
-	r, err := g.get(path, true)
-	if err != nil {
-		return nil, err
-	}
-	segments := strings.Split(msg.Path(name), "/")
-	records, err := g.loopNodes(r.Kvs, segments, false, nil)
-	if err != nil {
-		return nil, err
-	}
-	if len(records) != 1 {
-		return nil, fmt.Errorf("must be only one service record")
-	}
-	return &records[0], nil
-}
-
 // get is a wrapper for client.Get that uses SingleInflight to suppress multiple
 // outstanding queries.
 func (g *Backend) get(path string, recursive bool) (*etcd.Response, error) {
@@ -146,34 +96,6 @@ func (g *Backend) get(path string, recursive bool) (*etcd.Response, error) {
 		return nil, err
 	}
 	return resp.(*etcd.Response), err
-}
-
-func (g *Backendv3) get(path string, recursive bool) (*etcdv3.GetResponse, error) {
-	resp, err := g.inflight.Do(path, func() (interface{}, error) {
-		if recursive == true {
-			r, e := g.client.Get(g.ctx, path, etcdv3.WithPrefix())
-			if r.Kvs == nil {
-				return nil, fmt.Errorf("ErrorCodeKeyNotFound")
-			}
-			if e != nil {
-				return nil, e
-			}
-			return r, e
-		} else {
-			r, e := g.client.Get(g.ctx, path)
-			if r.Kvs == nil {
-				return nil, fmt.Errorf("ErrorCodeKeyNotFound")
-			}
-			if e != nil {
-				return nil, e
-			}
-			return r, e
-		}
-	})
-	if err != nil {
-		return nil, err
-	}
-	return resp.(*etcdv3.GetResponse), err
 }
 
 type bareService struct {
@@ -241,39 +163,6 @@ Nodes:
 	return sx, nil
 }
 
-func (g *Backendv3) loopNodes(kv []*mvccpb.KeyValue, nameParts []string, star bool, bx map[bareService]bool) (sx []msg.Service, err error) {
-	if bx == nil {
-		bx = make(map[bareService]bool)
-	}
-
-	index := 0
-	lengthOfEntries := len(kv)
-	for index < lengthOfEntries {
-
-		serviceInstance := new(msg.Service)
-
-		if err := json.Unmarshal(kv[index].Value, serviceInstance); err != nil {
-			return nil, err
-		}
-
-		b := bareService{serviceInstance.Host, serviceInstance.Port, serviceInstance.Priority, serviceInstance.Weight, serviceInstance.Text}
-
-		bx[b] = true
-		serviceInstance.Key = string(kv[index].Key)
-		//TODO: shouldn't be that another call (LeaseRequest) for TTL
-		serviceInstance.Ttl = g.calculateTtl(kv[index], serviceInstance)
-
-		if serviceInstance.Priority == 0 {
-			serviceInstance.Priority = int(g.config.Priority)
-		}
-
-		sx = append(sx, *serviceInstance)
-		index++
-	}
-
-	return sx, nil
-}
-
 // calculateTtl returns the smaller of the etcd TTL and the service's
 // TTL. If neither of these are set (have a zero value), the server
 // default is used.
@@ -295,29 +184,7 @@ func (g *Backend) calculateTtl(node *etcd.Node, serv *msg.Service) uint32 {
 	return serv.Ttl
 }
 
-func (g *Backendv3) calculateTtl(kv *mvccpb.KeyValue, serv *msg.Service) uint32 {
-	etcdTtl := uint32(kv.Lease) //TODO: still waiting for Least request rpc to be available in etcdv3's api
-
-	if etcdTtl == 0 && serv.Ttl == 0 {
-		return g.config.Ttl
-	}
-	if etcdTtl == 0 {
-		return serv.Ttl
-	}
-	if serv.Ttl == 0 {
-		return etcdTtl
-	}
-	if etcdTtl < serv.Ttl {
-		return etcdTtl
-	}
-	return serv.Ttl
-}
-
 // Client exposes the underlying Etcd client (used in tests).
 func (g *Backend) Client() etcd.KeysAPI {
-       return g.client
-}
-
-func (g *Backendv3) Client() etcdv3.Client {
 	return g.client
 }

--- a/backends/etcd/etcd.go
+++ b/backends/etcd/etcd.go
@@ -15,7 +15,9 @@ import (
 	"github.com/skynetservices/skydns/singleflight"
 
 	etcd "github.com/coreos/etcd/client"
+	etcdv3 "github.com/coreos/etcd/clientv3"
 	"golang.org/x/net/context"
+	"github.com/coreos/etcd/mvcc/mvccpb"
 )
 
 // Config represents configuration for the Etcd backend - these values
@@ -32,9 +34,26 @@ type Backend struct {
 	inflight *singleflight.Group
 }
 
+type Backendv3 struct {
+	client   etcdv3.Client
+	ctx      context.Context
+	config   *Config
+	inflight *singleflight.Group
+}
+
 // NewBackend returns a new Backend for SkyDNS, backed by etcd.
 func NewBackend(client etcd.KeysAPI, ctx context.Context, config *Config) *Backend {
 	return &Backend{
+		client:   client,
+		ctx:      ctx,
+		config:   config,
+		inflight: &singleflight.Group{},
+	}
+}
+
+// NewBackendv3 returns a new Backend for SkyDNS, backed by etcd v3
+func NewBackendv3(client etcdv3.Client, ctx context.Context, config *Config) *Backendv3 {
+	return &Backendv3{
 		client:   client,
 		ctx:      ctx,
 		config:   config,
@@ -57,6 +76,17 @@ func (g *Backend) Records(name string, exact bool) ([]msg.Service, error) {
 	default:
 		return g.loopNodes([]*etcd.Node{r.Node}, segments, false, nil)
 	}
+}
+
+func (g *Backendv3) Records(name string, exact bool) ([]msg.Service, error) {
+	path, star := msg.PathWithWildcard(name)
+	r, err := g.get(path, true)
+	if err != nil {
+		return nil, err
+	}
+	segments := strings.Split(msg.Path(name), "/")
+
+	return g.loopNodes(r.Kvs, segments, star, nil)
 }
 
 func (g *Backend) ReverseRecord(name string) (*msg.Service, error) {
@@ -82,6 +112,26 @@ func (g *Backend) ReverseRecord(name string) (*msg.Service, error) {
 	return &records[0], nil
 }
 
+func (g *Backendv3) ReverseRecord(name string) (*msg.Service, error) {
+	path, star := msg.PathWithWildcard(name)
+	if star {
+		return nil, fmt.Errorf("reverse can not contain wildcards")
+	}
+	r, err := g.get(path, true)
+	if err != nil {
+		return nil, err
+	}
+	segments := strings.Split(msg.Path(name), "/")
+	records, err := g.loopNodes(r.Kvs, segments, false, nil)
+	if err != nil {
+		return nil, err
+	}
+	if len(records) != 1 {
+		return nil, fmt.Errorf("must be only one service record")
+	}
+	return &records[0], nil
+}
+
 // get is a wrapper for client.Get that uses SingleInflight to suppress multiple
 // outstanding queries.
 func (g *Backend) get(path string, recursive bool) (*etcd.Response, error) {
@@ -96,6 +146,34 @@ func (g *Backend) get(path string, recursive bool) (*etcd.Response, error) {
 		return nil, err
 	}
 	return resp.(*etcd.Response), err
+}
+
+func (g *Backendv3) get(path string, recursive bool) (*etcdv3.GetResponse, error) {
+	resp, err := g.inflight.Do(path, func() (interface{}, error) {
+		if recursive == true {
+			r, e := g.client.Get(g.ctx, path, etcdv3.WithPrefix())
+			if r.Kvs == nil {
+				return nil, fmt.Errorf("ErrorCodeKeyNotFound")
+			}
+			if e != nil {
+				return nil, e
+			}
+			return r, e
+		} else {
+			r, e := g.client.Get(g.ctx, path)
+			if r.Kvs == nil {
+				return nil, fmt.Errorf("ErrorCodeKeyNotFound")
+			}
+			if e != nil {
+				return nil, e
+			}
+			return r, e
+		}
+	})
+	if err != nil {
+		return nil, err
+	}
+	return resp.(*etcdv3.GetResponse), err
 }
 
 type bareService struct {
@@ -163,6 +241,39 @@ Nodes:
 	return sx, nil
 }
 
+func (g *Backendv3) loopNodes(kv []*mvccpb.KeyValue, nameParts []string, star bool, bx map[bareService]bool) (sx []msg.Service, err error) {
+	if bx == nil {
+		bx = make(map[bareService]bool)
+	}
+
+	index := 0
+	lengthOfEntries := len(kv)
+	for index < lengthOfEntries {
+
+		serviceInstance := new(msg.Service)
+
+		if err := json.Unmarshal(kv[index].Value, serviceInstance); err != nil {
+			return nil, err
+		}
+
+		b := bareService{serviceInstance.Host, serviceInstance.Port, serviceInstance.Priority, serviceInstance.Weight, serviceInstance.Text}
+
+		bx[b] = true
+		serviceInstance.Key = string(kv[index].Key)
+		//TODO: shouldn't be that another call (LeaseRequest) for TTL
+		serviceInstance.Ttl = g.calculateTtl(kv[index], serviceInstance)
+
+		if serviceInstance.Priority == 0 {
+			serviceInstance.Priority = int(g.config.Priority)
+		}
+
+		sx = append(sx, *serviceInstance)
+		index++
+	}
+
+	return sx, nil
+}
+
 // calculateTtl returns the smaller of the etcd TTL and the service's
 // TTL. If neither of these are set (have a zero value), the server
 // default is used.
@@ -184,7 +295,29 @@ func (g *Backend) calculateTtl(node *etcd.Node, serv *msg.Service) uint32 {
 	return serv.Ttl
 }
 
+func (g *Backendv3) calculateTtl(kv *mvccpb.KeyValue, serv *msg.Service) uint32 {
+	etcdTtl := uint32(kv.Lease) //TODO: still waiting for Least request rpc to be available in etcdv3's api
+
+	if etcdTtl == 0 && serv.Ttl == 0 {
+		return g.config.Ttl
+	}
+	if etcdTtl == 0 {
+		return serv.Ttl
+	}
+	if serv.Ttl == 0 {
+		return etcdTtl
+	}
+	if etcdTtl < serv.Ttl {
+		return etcdTtl
+	}
+	return serv.Ttl
+}
+
 // Client exposes the underlying Etcd client (used in tests).
 func (g *Backend) Client() etcd.KeysAPI {
        return g.client
+}
+
+func (g *Backendv3) Client() etcdv3.Client {
+	return g.client
 }

--- a/backends/etcd3/etcd3.go
+++ b/backends/etcd3/etcd3.go
@@ -1,0 +1,162 @@
+// Copyright (c) 2014 The SkyDNS Authors. All rights reserved.
+// Use of this source code is governed by The MIT License (MIT) that can be
+// found in the LICENSE file.
+
+// Package etcd provides the default SkyDNS server Backend implementation,
+// which looks up records stored under the `/skydns` key in etcd when queried.
+// This one particularly concerns with the support of etcd version 3.
+package etcd3
+
+import (
+	etcdv3 "github.com/coreos/etcd/clientv3"
+	"golang.org/x/net/context"
+	"github.com/skynetservices/skydns/singleflight"
+	"strings"
+	"github.com/skynetservices/skydns/msg"
+	"fmt"
+	"github.com/coreos/etcd/mvcc/mvccpb"
+	"encoding/json"
+)
+
+type Config struct {
+	Ttl uint32
+	Priority uint16
+}
+
+type Backendv3 struct {
+	client etcdv3.Client
+	ctx context.Context
+	config *Config
+	inflight *singleflight.Group
+}
+
+// NewBackendv3 returns a new Backend for SkyDNS, backed by etcd v3
+func NewBackendv3 (client etcdv3.Client, ctx context.Context, config *Config) *Backendv3 {
+	return &Backendv3{
+		client: client,
+		ctx: ctx,
+		config: config,
+		inflight: &singleflight.Group{},
+	}
+}
+
+func (g *Backendv3) Records(name string, exact bool) ([]msg.Service, error) {
+	path, star := msg.PathWithWildcard(name)
+	r, err := g.get(path, true)
+	if err != nil {
+		return nil, err
+	}
+	segments := strings.Split(msg.Path(name), "/")
+
+	return g.loopNodes(r.Kvs, segments, star, nil)
+}
+
+func (g *Backendv3) ReverseRecord(name string) (*msg.Service, error) {
+	path, star := msg.PathWithWildcard(name)
+	if star {
+		return nil, fmt.Errorf("reverse can not contain wildcards")
+	}
+
+	r, err := g.get(path, true)
+	if err != nil {
+		return nil, err
+	}
+
+	segments := strings.Split(msg.Path(name), "/")
+	records, err := g.loopNodes(r.Kvs, segments, false, nil)
+	if err != nil {
+		return nil, err
+	}
+	if len(records) != 1 {
+		return nil, fmt.Errorf("must be only one service record")
+	}
+	return &records[0], nil
+}
+
+func (g *Backendv3) get(path string, recursive bool) (*etcdv3.GetResponse, error) {
+	resp, err := g.inflight.Do(path, func() (interface{}, error){
+		if recursive == true {
+			r, e := g.client.Get(g.ctx, path, etcdv3.WithPrefix())
+			if e != nil {
+				return nil, e
+			}
+			return r, e
+		} else {
+			r, e := g.client.Get(g.ctx, path)
+			if e != nil {
+				return nil, e
+			}
+			return r, e
+		}
+	})
+
+	if err != nil {
+		return nil, err
+	}
+	return resp.(*etcdv3.GetResponse), err
+}
+
+type bareService struct {
+	Host string
+	Port int
+	Priority int
+	Weight int
+	Text string
+}
+
+func (g *Backendv3) loopNodes(kv []*mvccpb.KeyValue, nameParts []string, star bool, bx map[bareService]bool) (sx []msg.Service, err error) {
+	if bx == nil {
+		bx = make(map[bareService]bool)
+	}
+
+	index := 0
+	lengthOfEntries := len(kv)
+	for index < lengthOfEntries {
+
+		serviceInstance := new(msg.Service)
+		if err := json.Unmarshal(kv[index].Value, serviceInstance); err != nil {
+			return nil, err
+		}
+
+		b := bareService{serviceInstance.Host,
+				 serviceInstance.Port,
+				 serviceInstance.Priority,
+				 serviceInstance.Weight,
+			 	 serviceInstance.Text}
+
+		bx[b] = true
+		serviceInstance.Key = string(kv[index].Key)
+		//TODO: another call (LeaseRequest) for TTL when RPC in etcdv3 is ready
+		serviceInstance.Ttl = g.calculateTtl(kv[index], serviceInstance)
+
+		if serviceInstance.Priority == 0 {
+			serviceInstance.Priority = int(g.config.Priority)
+		}
+
+		sx = append(sx, *serviceInstance)
+		index++
+	}
+	return sx, nil
+}
+
+func (g *Backendv3) calculateTtl(kv *mvccpb.KeyValue, serv *msg.Service) uint32 {
+	etcdTtl := uint32(kv.Lease) //TODO: default value for now, should be an rpc call for least request when it becomes available in etcdv3's api
+
+	if etcdTtl == 0 && serv.Ttl == 0 {
+		return g.config.Ttl
+	}
+	if etcdTtl == 0 {
+		return serv.Ttl
+	}
+	if serv.Ttl == 0 {
+		return etcdTtl
+	}
+	if etcdTtl < serv.Ttl {
+		return etcdTtl
+	}
+	return serv.Ttl
+}
+
+func (g *Backendv3) Client() etcdv3.Client {
+	return g.client
+}

--- a/server/config.go
+++ b/server/config.go
@@ -59,6 +59,8 @@ type Config struct {
 	RCacheTtl int `json:"rcache_ttl,omitempty"`
 	// How many labels a name should have before we allow forwarding. Default to 2.
 	Ndots int `json:"ndot,omitempty"`
+	// EtcdVersion, the version supported during skydns' run. Default to 2.
+	EtcdVersion int
 
 	// DNSSEC key material
 	PubKey  *dns.DNSKEY   `json:"-"`

--- a/server/config.go
+++ b/server/config.go
@@ -59,8 +59,8 @@ type Config struct {
 	RCacheTtl int `json:"rcache_ttl,omitempty"`
 	// How many labels a name should have before we allow forwarding. Default to 2.
 	Ndots int `json:"ndot,omitempty"`
-	// EtcdVersion, the version supported during skydns' run. Default to 2.
-	EtcdVersion int
+	// Etcd flag that dictates if etcd version 3 is supported during skydns' run. Default to false.
+	Etcd3 bool
 
 	// DNSSEC key material
 	PubKey  *dns.DNSKEY   `json:"-"`


### PR DESCRIPTION
Aims to provide an parameter way of support for skydns.
Default skydns supports etcd v2.
TTL computation for etcd version 3 will be only by default, until RPC for its support is ready in etcdv3.
