### PR TITLE
Immediately forward truncate errors when proxying requests.

### DIFF
--- a/server/stub.go
+++ b/server/stub.go
@@ -103,7 +103,7 @@ Redo:
 	} else {
 		r, err = exchangeWithRetry(s.dnsUDPclient, req, ns[nsid])
 	}
-	if err == nil {
+	if err == nil || err == dns.ErrTruncated {
 		r.Compress = true
 		r.Id = req.Id
 		w.WriteMsg(r)


### PR DESCRIPTION
When a forwarded UDP stubzone request is unable to complete due to response truncation, the truncate message should be returned to the client so that the client may switch to TCP. How this should interact with retrying across multiple nameservers is less clear (what if a different nameserver would have returned a non-truncated response?)