### PR TITLE
First pass at a stubzones bugfix 

### DIFF
--- a/backends/etcd/etcd_test.go
+++ b/backends/etcd/etcd_test.go
@@ -1,0 +1,74 @@
+// Copyright (c) 2015 All Right Reserved, Improbable Worlds Ltd.
+
+package etcd
+
+import (
+	"encoding/json"
+	"os"
+	"testing"
+	"time"
+
+	etcd "github.com/coreos/etcd/client"
+	etcd_harness "github.com/mwitkow/go-etcd-harness"
+	"github.com/skynetservices/skydns/msg"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/stretchr/testify/suite"
+	"golang.org/x/net/context"
+)
+
+type etcdBackendTestSuite struct {
+	suite.Suite
+	etcdBackend *Backend
+}
+
+func (s *etcdBackendTestSuite) SetupTest() {
+	s.etcdBackend.client.Delete(context.TODO(), "skydns", &etcd.DeleteOptions{Recursive: true, Dir: true})
+}
+
+func (s *etcdBackendTestSuite) TestGettingSingleRecordShouldReturnCorrectService() {
+	s.createEtcdRecord(msg.Service{Host: "1.1.1.1", Key: "/skydns/com/test"})
+	records, err := s.etcdBackend.Records("test.com", true, false)
+	assert.NoError(s.T(), err, "no err")
+	assert.Equal(s.T(), 1, len(records))
+	assert.Equal(s.T(), "1.1.1.1", records[0].Host)
+}
+
+func (s *etcdBackendTestSuite) TestStubZone() {
+	s.createEtcdRecord(msg.Service{Host: "1.1.1.1", Key: "/skydns/com/test/dns/stub/com/othertest/a/stubzone1/a"})
+	s.createEtcdRecord(msg.Service{Host: "1.1.1.2", Key: "/skydns/com/test/dns/stub/com/othertest/a/stubzone1/b"})
+	s.createEtcdRecord(msg.Service{Host: "1.1.1.1", Key: "/skydns/com/test/dns/stub/com/othertest/stubzone2/b"})
+	s.createEtcdRecord(msg.Service{Host: "1.1.1.2", Key: "/skydns/com/test/dns/stub/com/othertest/stubzone2/a"})
+	records, err := s.etcdBackend.Records("stub.dns.test.com", false, true)
+	assert.NoError(s.T(), err)
+	assert.Equal(s.T(), 4, len(records))
+}
+
+func TestDeploymentServiceSuite(t *testing.T) {
+	if testing.Short() {
+		t.Skipf("DeploymentServiceSuite is a long integration test suite. Skipping due to test short.")
+	}
+	if !etcd_harness.LocalEtcdAvailable() {
+		t.Skipf("etcd is not available in $PATH, skipping suite")
+	}
+
+	server, err := etcd_harness.New(os.Stderr)
+	if err != nil {
+		t.Fatalf("failed starting test server: %v", err)
+	}
+	t.Logf("will use etcd test endpoint: %v", server.Endpoint)
+	defer func() {
+		server.Stop()
+		t.Logf("cleaned up etcd test server")
+	}()
+	etcdClient := etcd.NewKeysAPI(server.Client)
+	suite.Run(t, &etcdBackendTestSuite{etcdBackend: NewBackend(etcdClient, context.TODO(), &Config{})})
+}
+
+func (s *etcdBackendTestSuite) createEtcdRecord(srv msg.Service) {
+	ctx, _ := context.WithTimeout(context.TODO(), time.Second*5)
+	value, err := json.Marshal(srv)
+	require.NoError(s.T(), err, "marshaling etcd record should not fail")
+	_, err = s.etcdBackend.client.Create(ctx, srv.Key, string(value))
+	require.NoError(s.T(), err, "creating etcd record should not fail")
+}

--- a/server/backend.go
+++ b/server/backend.go
@@ -7,7 +7,7 @@ package server
 import "github.com/skynetservices/skydns/msg"
 
 type Backend interface {
-	Records(name string, exact bool) ([]msg.Service, error)
+	Records(name string, exact bool, stub bool) ([]msg.Service, error)
 	ReverseRecord(name string) (*msg.Service, error)
 }
 
@@ -19,10 +19,10 @@ type FirstBackend []Backend
 // FirstBackend implements Backend
 var _ Backend = FirstBackend{}
 
-func (g FirstBackend) Records(name string, exact bool) (records []msg.Service, err error) {
+func (g FirstBackend) Records(name string, exact bool, stub bool) (records []msg.Service, err error) {
 	var lastError error
 	for _, backend := range g {
-		if records, err = backend.Records(name, exact); err == nil && len(records) > 0 {
+		if records, err = backend.Records(name, exact, stub); err == nil && len(records) > 0 {
 			return records, nil
 		}
 		if err != nil {

--- a/server/server.go
+++ b/server/server.go
@@ -419,7 +419,7 @@ func (s *server) ServeDNS(w dns.ResponseWriter, req *dns.Msg) {
 }
 
 func (s *server) AddressRecords(q dns.Question, name string, previousRecords []dns.RR, bufsize uint16, dnssec, both bool) (records []dns.RR, err error) {
-	services, err := s.backend.Records(name, false)
+	services, err := s.backend.Records(name, false, false)
 	if err != nil {
 		return nil, err
 	}
@@ -485,7 +485,7 @@ func (s *server) AddressRecords(q dns.Question, name string, previousRecords []d
 
 // NSRecords returns NS records from etcd.
 func (s *server) NSRecords(q dns.Question, name string) (records []dns.RR, extra []dns.RR, err error) {
-	services, err := s.backend.Records(name, false)
+	services, err := s.backend.Records(name, false, false)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -513,7 +513,7 @@ func (s *server) NSRecords(q dns.Question, name string) (records []dns.RR, extra
 // SRVRecords returns SRV records from etcd.
 // If the Target is not a name but an IP address, a name is created.
 func (s *server) SRVRecords(q dns.Question, name string, bufsize uint16, dnssec bool) (records []dns.RR, extra []dns.RR, err error) {
-	services, err := s.backend.Records(name, false)
+	services, err := s.backend.Records(name, false, false)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -598,7 +598,7 @@ func (s *server) SRVRecords(q dns.Question, name string, bufsize uint16, dnssec 
 // MXRecords returns MX records from etcd.
 // If the Target is not a name but an IP address, a name is created.
 func (s *server) MXRecords(q dns.Question, name string, bufsize uint16, dnssec bool) (records []dns.RR, extra []dns.RR, err error) {
-	services, err := s.backend.Records(name, false)
+	services, err := s.backend.Records(name, false, false)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -655,7 +655,7 @@ func (s *server) MXRecords(q dns.Question, name string, bufsize uint16, dnssec b
 }
 
 func (s *server) CNAMERecords(q dns.Question, name string) (records []dns.RR, err error) {
-	services, err := s.backend.Records(name, true)
+	services, err := s.backend.Records(name, true, false)
 	if err != nil {
 		return nil, err
 	}
@@ -672,7 +672,7 @@ func (s *server) CNAMERecords(q dns.Question, name string) (records []dns.RR, er
 }
 
 func (s *server) TXTRecords(q dns.Question, name string) (records []dns.RR, err error) {
-	services, err := s.backend.Records(name, false)
+	services, err := s.backend.Records(name, false, false)
 	if err != nil {
 		return nil, err
 	}

--- a/server/stub.go
+++ b/server/stub.go
@@ -34,7 +34,7 @@ var ednsStub = func() *dns.OPT {
 func (s *server) UpdateStubZones() {
 	stubmap := make(map[string][]string)
 
-	services, err := s.backend.Records("stub.dns."+s.config.Domain, false)
+	services, err := s.backend.Records("stub.dns."+s.config.Domain, false, true)
 	if err != nil {
 		logf("stub zone update failed: %s", err)
 		return


### PR DESCRIPTION
This PR addresses the following issue.
Say you have 2 stubzones registered in etcd the following way:
```
/skydns/com/test/dns/stub/com/othertest/a/stubzone1/a    1.1.1.1
/skydns/com/test/dns/stub/com/othertest/a/stubzone1/b    1.1.1.2
/skydns/com/test/dns/stub/com/othertest/stubzone2/b       1.1.1.1
/skydns/com/test/dns/stub/com/othertest/stubzone2/a       1.1.1.2
```

Current implementation will consider these records duplicate and one of the stubzones will not be available. 

To avoid this when we are looking up stubzone records we keep track of the subdomain in this case `stubzone1.a.othertest.com` and `stubzone2.othertest.com` and dedup records only inside the same subdomian.

I am not sure if this should be behind the flag `stub` or this can work as a general implementation.