### PR TITLE
Setting VERBOSE environment variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,6 +132,7 @@ SkyDNS uses these environment variables:
 * `SKYDNS_PATH_PREFIX` - backend(etcd) path prefix, defaults to skydns (i.e. if it is set to `mydns`, the SkyDNS's configuration object should be stored under the key `/mydns/config`). Overwrite with `-path-prefix` string flag.
 * `SKYDNS_SYSTEMD`: set to `true` to bind to socket(s) activated by systemd (ignores SKYDNS_ADDR). Overwrite with `-systemd` bool flag.
 * `SKYDNS_NDOTS`: how many labels a name should have before we allow forwarding. Default to 2.
+* `VERBOSE`: log the queries made againt the server. Defaults to false
 
 For [Prometheus](http://prometheus.io/) the following environment variables
 are available:

--- a/main.go
+++ b/main.go
@@ -85,7 +85,7 @@ func init() {
 	flag.BoolVar(&config.RoundRobin, "round-robin", true, "round robin A/AAAA replies")
 	flag.BoolVar(&config.NSRotate, "ns-rotate", true, "round robin selection of nameservers from among those listed")
 	flag.BoolVar(&stub, "stubzones", false, "support stub zones")
-	flag.BoolVar(&config.Verbose, "verbose", false, "log queries")
+	flag.BoolVar(&config.Verbose, "verbose", boolEnv("VERBOSE", false), "log queries")
 	flag.BoolVar(&config.Systemd, "systemd", boolEnv("SKYDNS_SYSTEMD", false), "bind to socket(s) activated by systemd (ignore -addr)")
 
 	// Version
@@ -154,7 +154,6 @@ func main() {
 		}
 	}
 
-
 	if err := server.SetDefaults(config); err != nil {
 		log.Fatalf("skydns: defaults could not be set from /etc/resolv.conf: %v", err)
 	}
@@ -163,16 +162,15 @@ func main() {
 		config.Local = dns.Fqdn(config.Local)
 	}
 
-
 	var backend server.Backend
 	if config.Etcd3 {
 		backend = backendetcdv3.NewBackendv3(clientv3, ctx, &backendetcdv3.Config{
-			Ttl: config.Ttl,
+			Ttl:      config.Ttl,
 			Priority: config.Priority,
 		})
 	} else {
 		backend = backendetcd.NewBackend(clientv2, ctx, &backendetcd.Config{
-			Ttl: config.Ttl,
+			Ttl:      config.Ttl,
 			Priority: config.Priority,
 		})
 	}
@@ -185,14 +183,14 @@ func main() {
 
 			if config.Etcd3 {
 				var watcher etcdv3.WatchChan
-				watcher = clientv3.Watch(ctx, msg.Path(config.Domain) + "/dns/stub/", etcdv3.WithPrefix())
+				watcher = clientv3.Watch(ctx, msg.Path(config.Domain)+"/dns/stub/", etcdv3.WithPrefix())
 
 				for wresp := range watcher {
 					if wresp.Err() != nil {
 						log.Printf("skydns: stubzone update failed, sleeping %s + ~3s", duration)
 						time.Sleep(duration + (time.Duration(rand.Float32() * 3e9)))
 						duration *= 2
-						if duration > 32 * time.Second {
+						if duration > 32*time.Second {
 							duration = 32 * time.Second
 						}
 					} else {
@@ -307,10 +305,9 @@ func newEtcdV3Client(machines []string, tlsCert, tlsKey, tlsCACert string) (*etc
 		return nil, err
 	}
 
-
-	etcdCfg := etcdv3.Config {
+	etcdCfg := etcdv3.Config{
 		Endpoints: machines,
-		TLS: tr.TLSClientConfig,
+		TLS:       tr.TLSClientConfig,
 	}
 	cli, err := etcdv3.New(etcdCfg)
 	if err != nil {


### PR DESCRIPTION
Added the ability to set verbose through the VERBOSE environment variable. This is useful when running SkyDNS in a docker container.
Also ran gofmt on the code.