### PR TITLE
Feature/etcd3 filter results

### DIFF
--- a/main.go
+++ b/main.go
@@ -312,6 +312,11 @@ func newEtcdV3Client(machines []string, tlsCert, tlsKey, tlsCACert string) (*etc
 		Endpoints: machines,
 		TLS: tr.TLSClientConfig,
 	}
+
+	if tlsCert == "" || tlsKey == "" || tlsCACert == "" {
+		etcdCfg.TLS = nil
+	}
+
 	cli, err := etcdv3.New(etcdCfg)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
This PR is supposed to correct a bug coming from the differences of etcd v2 and v3 APIs.
etcd V2 has a directory-like key space while the v3 API has a flat key space. For example if we have the following keys in etcd:
/skydns/local/domain
/skydns/local/domain/sub1
/skydns/local/domain/sub2
/skydns/local/domain2
/skydns/local/domain2/sub1
/skydns/local/domain2/sub2

Then a V2 recursive get with the path /skydns/local/domain will return only the first 3 keys, while a V3 "withPrefix" get will return all 6 entries, since the path is a string prefix of all of them.

The PR is supposed to correct this difference with filtering the reults coming from a V3 backend.