### PR TITLE
filter the output of etcdv3 queries to avoid false results caused by …

### DIFF
--- a/main.go
+++ b/main.go
@@ -312,6 +312,11 @@ func newEtcdV3Client(machines []string, tlsCert, tlsKey, tlsCACert string) (*etc
 		Endpoints: machines,
 		TLS: tr.TLSClientConfig,
 	}
+
+	if tlsCert == "" || tlsKey == "" || tlsCACert == "" {
+		etcdCfg.TLS = nil
+	}
+
 	cli, err := etcdv3.New(etcdCfg)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
…accidental prefix matches

Etcd api v3 has a flat namespace (no directories). So with the following entries in etcd:
/skydns/local/domain
/skydns/local/domain/sub1
/skydns/local/domain/sub2
/skydns/local/domain2
/skydns/local/domain2/sub1
/skydns/local/domain2/sub2

the prefix search with /skydns/local/domain will return all entries and not just the first three.

the filter will return only those result entries which are either exact matches or contain the (path + '/') as a prefix.