### PR TITLE
Add HasSynced() to Backend interface

### DIFF
--- a/backends/etcd/etcd.go
+++ b/backends/etcd/etcd.go
@@ -42,6 +42,10 @@ func NewBackend(client etcd.KeysAPI, ctx context.Context, config *Config) *Backe
 	}
 }
 
+func (g *Backend) HasSynced() bool {
+	return true
+}
+
 func (g *Backend) Records(name string, exact bool) ([]msg.Service, error) {
 	path, star := msg.PathWithWildcard(name)
 	r, err := g.get(path, true)

--- a/backends/etcd3/etcd3.go
+++ b/backends/etcd3/etcd3.go
@@ -8,36 +8,41 @@
 package etcd3
 
 import (
-	etcdv3 "github.com/coreos/etcd/clientv3"
-	"golang.org/x/net/context"
-	"github.com/skynetservices/skydns/singleflight"
-	"strings"
-	"github.com/skynetservices/skydns/msg"
-	"fmt"
-	"github.com/coreos/etcd/mvcc/mvccpb"
 	"encoding/json"
+	"fmt"
+	"strings"
+
+	etcdv3 "github.com/coreos/etcd/clientv3"
+	"github.com/coreos/etcd/mvcc/mvccpb"
+	"github.com/skynetservices/skydns/msg"
+	"github.com/skynetservices/skydns/singleflight"
+	"golang.org/x/net/context"
 )
 
 type Config struct {
-	Ttl uint32
+	Ttl      uint32
 	Priority uint16
 }
 
 type Backendv3 struct {
-	client etcdv3.Client
-	ctx context.Context
-	config *Config
+	client   etcdv3.Client
+	ctx      context.Context
+	config   *Config
 	inflight *singleflight.Group
 }
 
 // NewBackendv3 returns a new Backend for SkyDNS, backed by etcd v3
-func NewBackendv3 (client etcdv3.Client, ctx context.Context, config *Config) *Backendv3 {
+func NewBackendv3(client etcdv3.Client, ctx context.Context, config *Config) *Backendv3 {
 	return &Backendv3{
-		client: client,
-		ctx: ctx,
-		config: config,
+		client:   client,
+		ctx:      ctx,
+		config:   config,
 		inflight: &singleflight.Group{},
 	}
+}
+
+func (g *Backend) HasSynced() bool {
+	return true
 }
 
 func (g *Backendv3) Records(name string, exact bool) ([]msg.Service, error) {
@@ -74,7 +79,7 @@ func (g *Backendv3) ReverseRecord(name string) (*msg.Service, error) {
 }
 
 func (g *Backendv3) get(path string, recursive bool) (*etcdv3.GetResponse, error) {
-	resp, err := g.inflight.Do(path, func() (interface{}, error){
+	resp, err := g.inflight.Do(path, func() (interface{}, error) {
 		if recursive == true {
 			r, e := g.client.Get(g.ctx, path, etcdv3.WithPrefix())
 			if e != nil {
@@ -97,11 +102,11 @@ func (g *Backendv3) get(path string, recursive bool) (*etcdv3.GetResponse, error
 }
 
 type bareService struct {
-	Host string
-	Port int
+	Host     string
+	Port     int
 	Priority int
-	Weight int
-	Text string
+	Weight   int
+	Text     string
 }
 
 func (g *Backendv3) loopNodes(kv []*mvccpb.KeyValue, nameParts []string, star bool, bx map[bareService]bool) (sx []msg.Service, err error) {
@@ -127,17 +132,16 @@ Nodes:
 			}
 		}
 
-
 		serv := new(msg.Service)
 		if err := json.Unmarshal(item.Value, serv); err != nil {
 			return nil, err
 		}
 
 		b := bareService{serv.Host,
-				 serv.Port,
-				 serv.Priority,
-				 serv.Weight,
-				 serv.Text}
+			serv.Port,
+			serv.Priority,
+			serv.Weight,
+			serv.Text}
 
 		bx[b] = true
 		serv.Key = string(item.Key)

--- a/server/backend.go
+++ b/server/backend.go
@@ -7,6 +7,7 @@ package server
 import "github.com/skynetservices/skydns/msg"
 
 type Backend interface {
+	HasSynced() bool
 	Records(name string, exact bool) ([]msg.Service, error)
 	ReverseRecord(name string) (*msg.Service, error)
 }

--- a/server/server.go
+++ b/server/server.go
@@ -144,7 +144,7 @@ func (s *server) ServeDNS(w dns.ResponseWriter, req *dns.Msg) {
 	q := req.Question[0]
 	name := strings.ToLower(q.Name)
 
-	if q.Qtype == dns.TypeANY {
+	if q.Qtype == dns.TypeANY || !server.backed.HasSynced() {
 		m.Authoritative = false
 		m.Rcode = dns.RcodeRefused
 		m.RecursionAvailable = false
@@ -200,7 +200,7 @@ func (s *server) ServeDNS(w dns.ResponseWriter, req *dns.Msg) {
 	}
 
 	for zone, ns := range *s.config.stub {
-		if strings.HasSuffix(name, "." + zone) || name == zone {
+		if strings.HasSuffix(name, "."+zone) || name == zone {
 			metrics.ReportRequestCount(req, metrics.Stub)
 
 			resp := s.ServeDNSStubForward(w, req, ns)
@@ -232,7 +232,7 @@ func (s *server) ServeDNS(w dns.ResponseWriter, req *dns.Msg) {
 		return
 	}
 
-	if q.Qclass != dns.ClassCHAOS && !strings.HasSuffix(name, "." +s.config.Domain) && name != s.config.Domain {
+	if q.Qclass != dns.ClassCHAOS && !strings.HasSuffix(name, "."+s.config.Domain) && name != s.config.Domain {
 		metrics.ReportRequestCount(req, metrics.Rec)
 
 		resp := s.ServeDNSForward(w, req)


### PR DESCRIPTION
Adds HasSynced to Backend interface. This allows skydns to ensure that its backend has done whatever syncing it needs to do responding to queries (i.e syncing services & endpoints from k8s api server). This change is necessary to fix https://github.com/kubernetes/dns/issues/186. If the backend is not synced, then skydns will return REFUSED.

Despite being introduced because of a kube-dns issue, HasSynced() is still meant to be generic and can be used by any backend. If a backend does not care about syncing, it can simply return true in the implementation.
  
A corresponding change will be made in kube-dns to implement HasSynced(). 