### PR TITLE
Remove checking for ErrTruncated, which is now removed.

### DIFF
--- a/server/stub.go
+++ b/server/stub.go
@@ -103,7 +103,7 @@ Redo:
 	} else {
 		r, err = exchangeWithRetry(s.dnsUDPclient, req, ns[nsid])
 	}
-	if err == nil || err == dns.ErrTruncated {
+	if err == nil {
 		r.Compress = true
 		r.Id = req.Id
 		w.WriteMsg(r)


### PR DESCRIPTION
This was removed from miekg/dns in commit - https://github.com/miekg/dns/commit/1ff265a78454967a4321dc2c0e38e267323bc3d4#diff-8353741544373e78bb7c8c3f6a0ea2cc.
The commit message recommendatation is to check for the unpack error
which the current code is doing. Conn.ReadMsg returns err is unpack
fails.